### PR TITLE
Redo scenarios

### DIFF
--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -13,6 +13,7 @@ import socket
 import psutil
 import numpy as np
 import pylab as pl
+import pandas as pd
 import mpld3
 import re
 import sciris as sc
@@ -1772,28 +1773,20 @@ def get_param_groups(project_id, verbose=True):
     print('Getting parameter groups...')
     proj = load_project(project_id, die=True)
 
-    spending = sc.odict()
-    spending['years'] = sc.odict()
-    spending['vals'] = sc.odict()
+    # Start with empty JSON
+    param_groups = dict()
 
-    for pset in proj.progsets.values():
+    param_groups['groups'] = sc.odict()
+    param_groups['params'] = sc.odict()
 
-        y_min = proj.data.end_year
-        y_max = proj.data.end_year
-        for prog in pset.programs.values():
-            if prog.spend_data.has_time_data:
-                y_min = min(y_min,prog.spend_data.t[0])
-                y_max = max(y_max,prog.spend_data.t[-1])
-        spending['years'][pset.name] = np.arange(np.floor(y_min),np.ceil(y_max)+1)
-        spending['vals'][pset.name] = pset.get_alloc(spending['years'][pset.name])
-        spending['data_start'] = proj.data.start_year
-        spending['data_end'] = proj.data.end_year
+    param_groups['grouplist'] = pd.unique(proj.framework.pars['scenario'].dropna())
+
 
     if verbose:
-        print('Baseline spending:')
-        sc.pp(spending)
+        print('Parameter groups:')
+        sc.pp(param_groups)
 
-    return spending
+    return param_groups
 
 
 @RPC()

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1643,7 +1643,20 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
     elif js_scen['scentype'] == 'parameter':
         js_scen['paramyears'] = np.array([])
         js_scen['paramoverwrites'] = []
-        # TODO: pull the actual information out of scen.
+        scen_values = scen.scenario_values
+        extracted_param_years = False
+        for code_param_name in scen_values.keys():
+            for pop_name in scen_values[code_param_name].keys():
+                paramoverwrite_dict = dict()
+                paramoverwrite_dict['paramname'] = param_code_name_to_param_diaplay_name(code_param_name, proj)
+                paramoverwrite_dict['paramcodename'] = code_param_name
+                paramoverwrite_dict['groupname'] = param_code_name_to_param_group_name(code_param_name, proj)
+                paramoverwrite_dict['popname'] = pop_name
+                paramoverwrite_dict['paramvals'] = scen_values[code_param_name][pop_name]['y']
+                if not extracted_param_years:
+                    js_scen['paramyears'] = scen_values[code_param_name][pop_name]['t']
+                    extracted_param_years = True
+                js_scen['paramoverwrites'].append(paramoverwrite_dict)
 
     # Set up the programs information.
     js_scen['progs'] = []
@@ -1811,6 +1824,16 @@ def get_param_groups(project_id, verbose=True):
         sc.pp(param_groups)
 
     return param_groups
+
+
+def param_code_name_to_param_diaplay_name(code_name, proj):
+    param_diaplay_name = proj.framework.pars.loc[code_name, 'display name']
+    return param_diaplay_name
+
+
+def param_code_name_to_param_group_name(code_name, proj):
+    param_group_name = proj.framework.pars.loc[code_name, 'scenario']
+    return param_group_name
 
 
 @RPC()

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1616,7 +1616,7 @@ def py_to_js_scen(scen: at.CombinedScenario, proj=at.Project) -> dict:
     [coverageyears.update(x.t) for x in scen.instructions.alloc.values()]
     js_scen['coverageyears'] = np.array(sorted(coverageyears))
 
-    js_scen['progvals'] = []
+    js_scen['progs'] = []
 
     if scen.instructions:
         js_scen['program_start_year'] = scen.instructions.start_year
@@ -1666,7 +1666,7 @@ def py_to_js_scen(scen: at.CombinedScenario, proj=at.Project) -> dict:
         else:
             progdict['coveragevals'] = [None] * len(js_scen['coverageyears'])
 
-        js_scen['progvals'].append(progdict)
+        js_scen['progs'].append(progdict)
 
     return js_scen
 
@@ -1695,7 +1695,7 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
 
     alloc = sc.odict()
     coverage = sc.odict()
-    for prog in js_scen['progvals']:
+    for prog in js_scen['progs']:
         if any(prog['budgetvals']):
             budgetyears = [to_float(x) if sc.isstring(x) else x for x in js_scen['budgetyears']]
             alloc[prog['shortname']] = at.TimeSeries(budgetyears,[to_float(x) if x is not None else None for x in prog['budgetvals'] ])

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1707,6 +1707,25 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
     scen = at.CombinedScenario(name=name,active=active,parsetname=parsetname,progsetname=progsetname,scvalues=scvalues,instructions=instructions)
     return scen
 
+
+@RPC()
+def get_sim_params(project_id, verbose=True):
+    print('Getting simulation parameters...')
+    proj = load_project(project_id, die=True)
+
+    sim_params = sc.odict()
+    sim_params['sim_start_year'] = proj.settings.sim_start
+    sim_params['sim_end_year'] = proj.settings.sim_end
+
+    if verbose:
+        print('Start sim year:')
+        print(sim_params['sim_start_year'])
+        print('Start end year:')
+        print(sim_params['sim_end_year'])
+
+    return sim_params
+
+
 @RPC()
 def get_baseline_spending(project_id, verbose=True):
     print('Getting baseline spending...')
@@ -1732,7 +1751,7 @@ def get_baseline_spending(project_id, verbose=True):
     if verbose:
         print('Baseline spending:')
         sc.pp(spending)
-        
+
     return spending
 
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1623,7 +1623,9 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
 
     # Handle the special cases for parameter scenarios...
     elif js_scen['scentype'] == 'parameter':
-        pass
+        js_scen['paramyears'] = np.array([])
+        js_scen['params'] = []
+        # TODO: pull the actual information out of scen.
 
     # Set up the programs information.
     js_scen['progs'] = []
@@ -1690,7 +1692,8 @@ def js_to_py_scen(js_scen: dict) -> at.Scenario:
     parsetname = js_scen['parsetname']
     progsetname = js_scen['progsetname']
     scentype = js_scen['scentype']
-    start_year = to_float(js_scen['progstartyear']) if js_scen['progstartyear'] is not None else None
+    if 'progstartyear' in js_scen:
+        start_year = to_float(js_scen['progstartyear']) if js_scen['progstartyear'] is not None else None
 
     alloc = sc.odict()
     coverage = sc.odict()
@@ -1712,7 +1715,8 @@ def js_to_py_scen(js_scen: dict) -> at.Scenario:
         scen = at.CoverageScenario(name=name, active=active, parsetname=parsetname, progsetname=progsetname,
             coverage=coverage, start_year=start_year)
     elif scentype == 'parameter':
-        scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=None)
+        # scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=None)
+        scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=dict())
 
     return scen
 
@@ -1795,7 +1799,7 @@ def new_scen(project_id, scentype) -> dict:
 
     alloc = {}
     print('MAKESCEN')
-    for prog in proj.progsets[-1].programs.values():
+    for prog in proj.progsets[-1].programs.values():  # Start with programs in the last progset.
         print(prog.spend_data)
         if prog.spend_data.has_time_data:
             alloc[prog.name] = sc.dcp(prog.spend_data)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1768,6 +1768,35 @@ def get_baseline_spending(project_id, verbose=True):
 
 
 @RPC()
+def get_param_groups(project_id, verbose=True):
+    print('Getting parameter groups...')
+    proj = load_project(project_id, die=True)
+
+    spending = sc.odict()
+    spending['years'] = sc.odict()
+    spending['vals'] = sc.odict()
+
+    for pset in proj.progsets.values():
+
+        y_min = proj.data.end_year
+        y_max = proj.data.end_year
+        for prog in pset.programs.values():
+            if prog.spend_data.has_time_data:
+                y_min = min(y_min,prog.spend_data.t[0])
+                y_max = max(y_max,prog.spend_data.t[-1])
+        spending['years'][pset.name] = np.arange(np.floor(y_min),np.ceil(y_max)+1)
+        spending['vals'][pset.name] = pset.get_alloc(spending['years'][pset.name])
+        spending['data_start'] = proj.data.start_year
+        spending['data_end'] = proj.data.end_year
+
+    if verbose:
+        print('Baseline spending:')
+        sc.pp(spending)
+
+    return spending
+
+
+@RPC()
 def get_scen_info(project_id, verbose=True):
     print('Getting scenario info...')
     proj = load_project(project_id, die=True)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1708,24 +1708,6 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
 
 
 @RPC()
-def get_sim_params(project_id, verbose=True):
-    print('Getting simulation parameters...')
-    proj = load_project(project_id, die=True)
-
-    sim_params = sc.odict()
-    sim_params['sim_start_year'] = proj.settings.sim_start
-    sim_params['sim_end_year'] = proj.settings.sim_end
-
-    if verbose:
-        print('Start sim year:')
-        print(sim_params['sim_start_year'])
-        print('Start end year:')
-        print(sim_params['sim_end_year'])
-
-    return sim_params
-
-
-@RPC()
 def get_baseline_spending(project_id, verbose=True):
     print('Getting baseline spending...')
     proj = load_project(project_id, die=True)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1969,7 +1969,7 @@ def scen_change_progset(js_scen: dict,new_progset_name: str, project_id) -> dict
 
 
 @RPC()
-def scen_reset_spending(js_scen, project_id):
+def scen_reset_values(js_scen, project_id):
     py_scen = js_to_py_scen(js_scen)
     proj = load_project(project_id, die=True)
 
@@ -1990,6 +1990,12 @@ def scen_reset_spending(js_scen, project_id):
         # Create a new coverage scenario with the settings from the old.
         py_scen = at.CoverageScenario(name=py_scen.name, active=py_scen.active, parsetname=py_scen.parsetname,
             progsetname=py_scen.progsetname, coverage=None, start_year=py_scen.start_year)
+
+    # Handle the parameter scenario case...
+    elif isinstance(py_scen, at.ParameterScenario):
+        # Create a new parameter scenario with the settings from the old.
+        py_scen = at.ParameterScenario(name=py_scen.name, active=py_scen.active, parsetname=py_scen.parsetname,
+            scenario_values=dict())
 
     # Make the JSON for the scenario
     js_scen = py_to_js_scen(py_scen, proj)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1848,23 +1848,28 @@ def scen_change_progset(js_scen: dict,new_progset_name: str, project_id) -> dict
         py_scen.alloc = alloc
 
     # Handle the coverage scenario case...
+    # TODO: We ultimately need something that comes out of actually running the model.
     elif isinstance(py_scen, at.CoverageScenario):
-        old_coverage = py_scen.coverage
-        coverage = sc.odict()
+        # Create a new coverage scenario with the settings from the old, but with the new progset.
+        py_scen = at.CoverageScenario(name=py_scen.name, active=py_scen.active, parsetname=py_scen.parsetname,
+            progsetname=new_progset_name, coverage=None, start_year=py_scen.start_year)
 
-        # Fuse the coverages
-        # - If the new progset has the same programs, then leave them intact
-        # - If the new progset has a new program, draw values from the progbook
-        for prog in new_progset.programs.values():
-            if prog.name in old_coverage:
-                coverage[prog.name] = sc.dcp(old_coverage[prog.name])
-            else:
-                if prog.coverage.has_time_data:
-                    coverage[prog.name] = sc.dcp(prog.coverage)
-                else:
-                    coverage[prog.name] = at.TimeSeries(py_scen.start_year, prog.coverage.assumption)
-
-        py_scen.coverage = coverage
+        # old_coverage = py_scen.coverage
+        # coverage = sc.odict()
+        #
+        # # Fuse the coverages
+        # # - If the new progset has the same programs, then leave them intact
+        # # - If the new progset has a new program, draw values from the progbook
+        # for prog in new_progset.programs.values():
+        #     if prog.name in old_coverage:
+        #         coverage[prog.name] = sc.dcp(old_coverage[prog.name])
+        #     else:
+        #         if prog.coverage.has_time_data:
+        #             coverage[prog.name] = sc.dcp(prog.coverage)
+        #         else:
+        #             coverage[prog.name] = at.TimeSeries(py_scen.start_year, prog.coverage.assumption)
+        #
+        # py_scen.coverage = coverage
 
     py_scen.progsetname = new_progset_name
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1697,9 +1697,11 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
     coverage = sc.odict()
     for prog in js_scen['progvals']:
         if any(prog['budgetvals']):
-            alloc[prog['shortname']] = at.TimeSeries(js_scen['budgetyears'],[to_float(x) if x is not None else None for x in prog['budgetvals'] ])
+            budgetyears = [to_float(x) if sc.isstring(x) else x for x in js_scen['budgetyears']]
+            alloc[prog['shortname']] = at.TimeSeries(budgetyears,[to_float(x) if x is not None else None for x in prog['budgetvals'] ])
         if any(prog['coveragevals']):
-            coverage[prog['shortname']] = at.TimeSeries(js_scen['coverageyears'],[to_float(x)/100.0 if x is not None else None for x in prog['coveragevals']])
+            coverageyears = [to_float(x) if sc.isstring(x) else x for x in js_scen['coverageyears']]
+            coverage[prog['shortname']] = at.TimeSeries(coverageyears,[to_float(x)/100.0 if x is not None else None for x in prog['coveragevals']])
     instructions = at.ProgramInstructions(start_year=start_year,alloc=alloc,coverage=coverage)
 
     # Construct the scenario

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1811,7 +1811,7 @@ def new_scen(project_id, scentype) -> dict:
             progsetname=proj.progsets[-1].name, coverage=None, start_year=start_year)
     elif scentype == 'parameter':
         scen = at.ParameterScenario(name='New parameter scenario', active=True, parsetname=proj.parsets[-1].name,
-            scenario_values=None)
+            scenario_values=dict())
 
     # Make the JSON for the scenario
     js_scen = py_to_js_scen(scen, proj)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1733,8 +1733,23 @@ def js_to_py_scen(js_scen: dict) -> at.Scenario:
         scen = at.CoverageScenario(name=name, active=active, parsetname=parsetname, progsetname=progsetname,
             coverage=coverage, start_year=start_year)
     elif scentype == 'parameter':
-        # scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=None)
-        scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=dict())
+        scen_values = dict()
+        paramyears = []
+        if 'paramyears' in js_scen:
+            paramyears = js_scen['paramyears']
+        if 'paramoverwrites' in js_scen:
+            for paramoverwrite in js_scen['paramoverwrites']:
+                paramname = paramoverwrite['paramcodename']
+                if paramname not in scen_values:
+                    scen_values[paramname] = dict()
+                popname = paramoverwrite['popname']
+                if popname not in scen_values[paramname]:
+                    scen_values[paramname][popname] = dict()
+                scen_values[paramname][popname]['t'] = paramyears
+                paramvals = paramoverwrite['paramvals']
+                scen_values[paramname][popname]['y'] = paramvals
+
+        scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=scen_values)
 
     return scen
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1747,6 +1747,7 @@ def js_to_py_scen(js_scen: dict) -> at.Scenario:
                     scen_values[paramname][popname] = dict()
                 scen_values[paramname][popname]['t'] = paramyears
                 paramvals = paramoverwrite['paramvals']
+                paramvals = [to_float(pval) for pval in paramvals]
                 scen_values[paramname][popname]['y'] = paramvals
 
         scen = at.ParameterScenario(name=name, active=active, parsetname=parsetname, scenario_values=scen_values)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1417,6 +1417,15 @@ def customize_fig(fig=None, output=None, plotdata=None, xlims=None, figsize=None
 
 def get_budget_plots(results, year):
 
+    output = {'graphs': [], 'legends': []}
+    figs = []
+    legends = []
+
+    results = [x for x in results if x.used_programs] # Only include results that used programs
+    results = [x for x in results if not x.model.program_instructions.coverage] # Only include results that did NOT have coverage overwrites
+    if not results:
+        return output, figs, legends
+
     # Prepare data
     d = at.PlotData.programs(results, quantity='spending')
     d.interpolate(year)
@@ -1438,6 +1447,14 @@ def get_budget_plots(results, year):
     return output, figs, legends
 
 def get_coverage_plot(results):
+
+    output = {'graphs': [], 'legends': []}
+    figs = []
+    legends = []
+
+    results = [x for x in results if x.used_programs]  # Only include results that used programs
+    if not results:
+        return output, figs, legends
 
     # Coverage figures
     d = at.PlotData.programs(results, quantity='coverage_fraction', nan_outside=True)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1624,42 +1624,22 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
     # Handle the special cases for coverage scenarios...
     elif js_scen['scentype'] == 'coverage':
         js_scen['progstartyear'] = scen.start_year
-        js_scen['coverageyears'] = np.array([])
+        coverageyears = set()
+        [coverageyears.update(x.t) for x in scen.coverage.values()]
+        js_scen['coverageyears'] = np.array(sorted(coverageyears))
         js_scen['budgetyears'] = np.array([])
 
     # Handle the special cases for parameter scenarios...
     elif js_scen['scentype'] == 'parameter':
         pass
 
-
-
-
-    # TODO - add in parameter overwrites here
-
-    # Work out the budget years and coverage years
-    # Fundamentally, this bit of code needs to populate the FE with placeholder None values
-    # in places where the scenario doesn't have an overwrite yet e.g. if the user has not overridden
-    # values for a particular program
-    # budgetyears = set()
-    # # [budgetyears.update(x.t) for x in scen.instructions.alloc.values()]
-    # [budgetyears.update(x.t) for x in scen.alloc.values()]
-    # js_scen['budgetyears'] = np.array(sorted(budgetyears))
-
-    # coverageyears = set()
-    # # [coverageyears.update(x.t) for x in scen.instructions.alloc.values()]
-    # [coverageyears.update(x.t) for x in scen.alloc.values()]
-    # js_scen['coverageyears'] = np.array(sorted(coverageyears))
-
-
-
+    # Set up the programs information.
     js_scen['progs'] = []
 
     if not proj.progsets:
         # If no progsets, we can't retrieve the full names from the short names in the instructions
-        # In that case, we don't show any program overwrite values at all
-        # TODO - test this!
+        # In that case, we don't show any program overwrite values at all.
         return js_scen # Abort early if there are no programs to add
-
 
     # Otherwise, populate the program values
     # If user has not selected a progset, then we need to populate the program list somehow
@@ -1704,7 +1684,7 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
     return js_scen
 
 
-def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
+def js_to_py_scen(js_scen: dict) -> at.Scenario:
     """
     Convert JSON content to an Atomica scenario
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1708,6 +1708,33 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
     return scen
 
 @RPC()
+def get_baseline_spending(project_id, verbose=True):
+    print('Getting baseline spending...')
+    proj = load_project(project_id, die=True)
+
+    spending = sc.odict()
+    spending['years'] = sc.odict()
+    spending['vals'] = sc.odict()
+
+    for pset in proj.progsets.values():
+
+        y_min = proj.data.end_year
+        y_max = proj.data.end_year
+        for prog in pset.programs.values():
+            if prog.spend_data.has_time_data:
+                y_min = min(y_min,prog.spend_data.t[0])
+                y_max = max(y_max,prog.spend_data.t[-1])
+        spending['years'][pset.name] = np.arange(np.floor(y_min),np.ceil(y_max)+1)
+        spending['vals'][pset.name] = pset.get_alloc(spending['years'][pset.name])
+
+    if verbose:
+        print('Baseline spending:')
+        sc.pp(spending)
+        
+    return spending
+
+
+@RPC()
 def get_scen_info(project_id, verbose=True):
     print('Getting scenario info...')
     proj = load_project(project_id, die=True)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1776,11 +1776,19 @@ def get_param_groups(project_id, verbose=True):
     # Start with empty JSON
     param_groups = dict()
 
-    param_groups['groups'] = sc.odict()
-    param_groups['params'] = sc.odict()
+    param_groups['groups'] = sc.odict()  # TODO: Do we need this?
+    param_groups['params'] = sc.odict()  # TODO: Do we need this?
 
+    # Get the list of parameter groups from the framework dataframe.
     param_groups['grouplist'] = pd.unique(proj.framework.pars['scenario'].dropna())
 
+    # Pull out a DataFrame only of the parameters that are in groups.
+    df = proj.framework.pars.loc[:, ['scenario', 'display name']].dropna().reset_index()
+
+    # Pull out arrays for the code names, group names, and display names.
+    param_groups['codenames'] = df['code name'].values
+    param_groups['groupnames'] = df['scenario'].values
+    param_groups['displaynames'] = df['display name'].values
 
     if verbose:
         print('Parameter groups:')

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1776,9 +1776,6 @@ def get_param_groups(project_id, verbose=True):
     # Start with empty JSON
     param_groups = dict()
 
-    param_groups['groups'] = sc.odict()  # TODO: Do we need this?
-    param_groups['params'] = sc.odict()  # TODO: Do we need this?
-
     # Get the list of parameter groups from the framework dataframe.
     param_groups['grouplist'] = pd.unique(proj.framework.pars['scenario'].dropna())
 
@@ -1789,6 +1786,9 @@ def get_param_groups(project_id, verbose=True):
     param_groups['codenames'] = df['code name'].values
     param_groups['groupnames'] = df['scenario'].values
     param_groups['displaynames'] = df['display name'].values
+
+    # Pull out the population names from the first parset.
+    param_groups['popnames'] = proj.parsets[0].pop_names
 
     if verbose:
         print('Parameter groups:')

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1642,7 +1642,7 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
     # Handle the special cases for parameter scenarios...
     elif js_scen['scentype'] == 'parameter':
         js_scen['paramyears'] = np.array([])
-        js_scen['params'] = []
+        js_scen['paramoverwrites'] = []
         # TODO: pull the actual information out of scen.
 
     # Set up the programs information.

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1688,7 +1688,7 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
 
     # Assemble parameter overwrites
     # TODO: Connect to FE form once it is written
-    scvalues = None
+    scenario_values = None
 
     # Parse and convert the budget and coverage into instructions
     start_year = to_float(js_scen['program_start_year']) if js_scen['program_start_year'] is not None else None # NB. If the progsetname is not None then an error will occur if the start year is None
@@ -1705,7 +1705,7 @@ def js_to_py_scen(js_scen: dict) -> at.CombinedScenario:
     instructions = at.ProgramInstructions(start_year=start_year,alloc=alloc,coverage=coverage)
 
     # Construct the scenario
-    scen = at.CombinedScenario(name=name,active=active,parsetname=parsetname,progsetname=progsetname,scvalues=scvalues,instructions=instructions)
+    scen = at.CombinedScenario(name=name,active=active,parsetname=parsetname,progsetname=progsetname,scenario_values=scenario_values,instructions=instructions)
     return scen
 
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1766,7 +1766,7 @@ def set_scen_info(project_id, scenario_jsons, verbose=True):
 
 
 @RPC()    
-def new_scen(project_id) -> dict:
+def new_scen(project_id, scen_type) -> dict:
     """
     Instantiate a new temporary scenario and return JS representation
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1875,7 +1875,9 @@ def scen_reset_spending(js_scen, project_id):
 
     # Handle the coverage scenario case...
     elif isinstance(py_scen, at.CoverageScenario):
-        pass
+        # Create a new coverage scenario with the settings from the old.
+        py_scen = at.CoverageScenario(name=py_scen.name, active=py_scen.active, parsetname=py_scen.parsetname,
+            progsetname=py_scen.progsetname, coverage=None, start_year=py_scen.start_year)
 
     # Make the JSON for the scenario
     js_scen = py_to_js_scen(py_scen, proj)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1874,7 +1874,7 @@ def scen_change_progset(js_scen: dict,new_progset_name: str, project_id) -> dict
 
         py_scen.alloc = alloc
         py_scen.progsetname = new_progset_name
-        
+
     # Handle the coverage scenario case...
     elif isinstance(py_scen, at.CoverageScenario):
         pass
@@ -1889,20 +1889,21 @@ def scen_reset_spending(js_scen, project_id):
     py_scen = js_to_py_scen(js_scen)
     proj = load_project(project_id, die=True)
 
+    # Handle the budget scenario case...
     if isinstance(py_scen, at.BudgetScenario):
-        pass
+        alloc = sc.odict()
+        for prog in proj.progsets[py_scen.progsetname].programs.values():
+            print(prog.spend_data)
+            if prog.spend_data.has_time_data:
+                alloc[prog.name] = sc.dcp(prog.spend_data)
+            else:
+                alloc[prog.name] = at.TimeSeries(py_scen.start_year, prog.spend_data.assumption)
+
+        py_scen.alloc = alloc
+
+    # Handle the coverage scenario case...
     elif isinstance(py_scen, at.CoverageScenario):
         pass
-
-    alloc = sc.odict()
-    for prog in proj.progsets[py_scen.progsetname].programs.values():
-        print(prog.spend_data)
-        if prog.spend_data.has_time_data:
-            alloc[prog.name] = sc.dcp(prog.spend_data)
-        else:
-            alloc[prog.name] = at.TimeSeries(py_scen.instructions.start_year,prog.spend_data.assumption)
-
-    py_scen.instructions.alloc = alloc
 
     # Make the JSON for the scenario
     js_scen = py_to_js_scen(py_scen, proj)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1609,8 +1609,10 @@ def py_to_js_scen(scen: at.CombinedScenario, proj=at.Project) -> dict:
     # Fundamentally, this bit of code needs to populate the FE with placeholder None values
     # in places where the scenario doesn't have an overwrite yet e.g. if the user has not overridden
     # values for a particular program
-    js_scen['budgetyears'] = np.arange(proj.data.end_year,proj.data.end_year+3) # Come up with a better way of doing this
-    js_scen['coverageyears'] = np.arange(proj.data.end_year,proj.data.end_year+3) # Come up with a better way of doing this
+    # js_scen['budgetyears'] = np.arange(proj.data.end_year,proj.data.end_year+3) # Come up with a better way of doing this
+    # js_scen['coverageyears'] = np.arange(proj.data.end_year,proj.data.end_year+3) # Come up with a better way of doing this
+    js_scen['budgetyears'] = np.arange(proj.data.end_year,proj.data.end_year+1)
+    js_scen['coverageyears'] = np.arange(proj.data.end_year,proj.data.end_year+1)
 
     js_scen['progvals'] = []
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1726,6 +1726,8 @@ def get_baseline_spending(project_id, verbose=True):
                 y_max = max(y_max,prog.spend_data.t[-1])
         spending['years'][pset.name] = np.arange(np.floor(y_min),np.ceil(y_max)+1)
         spending['vals'][pset.name] = pset.get_alloc(spending['years'][pset.name])
+        spending['data_start'] = proj.data.start_year
+        spending['data_end'] = proj.data.end_year
 
     if verbose:
         print('Baseline spending:')

--- a/atomica_apps/version.py
+++ b/atomica_apps/version.py
@@ -6,7 +6,7 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-__version__ = "1.3.0"
-__versiondate__ = "2019-03-13"
+__version__ = "2.0.0"
+__versiondate__ = "2019-04-12"
 __gitinfo__ = sc.gitinfo(__file__, verbose=False)
 

--- a/bin/install_client.py
+++ b/bin/install_client.py
@@ -12,4 +12,6 @@ for to_delete in ['package-lock.json', 'dist', 'node_modules']:
             os.remove(to_delete)
         except:
             shutil.rmtree(to_delete)
+    else:
+        print('Not removing %s, not found' % to_delete)
 os.system('npm install')

--- a/bin/install_client.py
+++ b/bin/install_client.py
@@ -5,10 +5,11 @@
 import os, shutil
 parentfolder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(parentfolder)
-if os.path.exists('package-lock.json'):
-    os.remove('package-lock.json')
-if os.path.exists('./dist'):    
-    shutil.rmtree('./dist')
-if os.path.exists('./node_modules/'):
-    shutil.rmtree('./node_modules/')
+for to_delete in ['package-lock.json', 'dist', 'node_modules']:
+    if os.path.exists(to_delete):
+        print('Removing %s' % to_delete)
+        try:
+            os.remove(to_delete)
+        except:
+            shutil.rmtree(to_delete)
 os.system('npm install')

--- a/bin/install_client.py
+++ b/bin/install_client.py
@@ -2,8 +2,13 @@
 # Install any missing client modules.
 # Version: 2019jan15
 
-import os
+import os, shutil
 parentfolder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(parentfolder)
-os.system('rm -rf package-lock.json ./dist ./node_modules/')
+if os.path.exists('package-lock.json'):
+    os.remove('package-lock.json')
+if os.path.exists('./dist'):    
+    shutil.rmtree('./dist')
+if os.path.exists('./node_modules/'):
+    shutil.rmtree('./node_modules/')
 os.system('npm install')

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.11",
     "normalize-scss": "^7.0.1",
     "popper.js": "^1.14.4",
-    "sciris-js": "^0.2.10",
+    "sciris-js": "^0.2.12",
     "vue": "^2.5.17",
     "vue-paper-dashboard": "git+https://github.com/creativetimofficial/vue-paper-dashboard.git",
     "vue-router": "^3.0.1",

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -13,8 +13,8 @@ var CalibrationMixin = {
         showPlotControls: false,
         hasGraphs: false,
         table: null, // Not actually used on this page
-        startYear: 0,
-        endYear: 2018, // TEMP FOR DEMO
+        simStartYear: 0,
+        simEndYear: 2018, // TEMP FOR DEMO
         activePop: "All",
         popOptions: [],
         plotOptions: [],
@@ -60,8 +60,8 @@ var CalibrationMixin = {
       if ((this.$store.state.activeProject.project !== undefined) &&
         (this.$store.state.activeProject.project.hasData) ) {
         console.log('created() called')
-        this.startYear = this.simStart
-        this.endYear = this.simEnd // CK: Uncomment to set the end year to 2035 instead of 2018
+        this.simStartYear = this.simStart
+        this.simEndYear = this.simEnd
         this.popOptions = this.activePops
         this.serverDatastoreId = this.$store.state.activeProject.project.id + ':calibration'
         this.getPlotOptions(this.$store.state.activeProject.project.id)
@@ -285,7 +285,7 @@ var CalibrationMixin = {
         ], {
           'parsetname': this.activeParset, 
           'plot_options': this.plotOptions,
-          'plotyear':this.endYear, 
+          'plotyear':this.simEndYear, 
           'pops':this.activePop, 
           'tool': this.toolName(), 
           'cascade':null
@@ -317,7 +317,7 @@ var CalibrationMixin = {
           'parsetname': this.activeParset, 
           'max_time': maxtime, 
           'plot_options': this.plotOptions,
-          'plotyear': this.endYear, 
+          'plotyear': this.simEndYear, 
           'pops': this.activePop, 
           'tool': this.toolName(), 
           'cascade':null

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -13,8 +13,8 @@ var OptimizationMixin = {
       showPlotControls: false,
       hasGraphs: false,
       table: null,
-      startYear: 0,
-      endYear: 2018, // TEMP FOR DEMO
+      simStartYear: 0,
+      simEndYear: 2018, // TEMP FOR DEMO
       activePop: "All",
       popOptions: [],
       plotOptions: [],
@@ -59,8 +59,8 @@ var OptimizationMixin = {
       (this.$store.state.activeProject.project.hasData) &&
       (this.$store.state.activeProject.project.hasPrograms)) {
       console.log('created() called')
-      this.startYear = this.simStart
-      this.endYear = this.simEnd
+      this.simStartYear = this.simStart
+      this.simEndYear = this.simEnd
       this.popOptions = this.activePops
       this.getPlotOptions(this.$store.state.activeProject.project.id)
         .then(response => {
@@ -329,7 +329,7 @@ var OptimizationMixin = {
       console.log('saveOptim() called')
       this.$modal.hide('add-optim')
       this.$sciris.start(this)
-      this.endYear = this.modalOptim.end_year
+      this.simEndYear = this.modalOptim.end_year
       let newOptim = _.cloneDeep(this.modalOptim) // Get the new optimization summary from the modal.
       let optimNames = [] // Get the list of all of the current optimization names.
       this.optimSummaries.forEach(optimSum => {
@@ -459,7 +459,7 @@ var OptimizationMixin = {
                 'plot_options': this.plotOptions, 
                 'maxtime': maxtime, 
                 'tool': this.toolName(), 
-                'plotyear': this.endYear, 
+                'plotyear': this.simEndYear, 
                 'pops': this.activePop, 
                 'cascade': null
               }

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -12,6 +12,8 @@ var ScenarioMixin = {
       showPlotControls: false,
       hasGraphs: false,
       table: null,
+      simStartYear: 0,
+      simEndYear: 2035,
       startYear: 0,
       endYear: 2018, // TEMP FOR DEMO
       activePop: "All",
@@ -30,6 +32,7 @@ var ScenarioMixin = {
       scenSummaries: [],
       spendingBaselines: {},
       validProgramStartYears: [],
+      validSimYears: [],
       scenariosLoaded: false,
       addEditModal: {
         scenSummary: {},
@@ -58,6 +61,11 @@ var ScenarioMixin = {
       (this.$store.state.activeProject.project.hasData) &&
       (this.$store.state.activeProject.project.hasPrograms)) {
       console.log('created() called')
+      this.validSimYears = []
+      for (var year = 2000; 
+        year <= 2035; year++) {
+        this.validSimYears.push(year)
+      }
       this.startYear = this.simStart
       this.endYear = this.simEnd
       this.popOptions = this.activePops

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -156,14 +156,12 @@ var ScenarioMixin = {
       // TODO: I'm thinking we don't really need this RPC call, since the default budget
       // scenario gets loaded on creation of the page.
       // Or, alternatively, we should take the call out of the create() function.
-      this.$sciris.rpc('get_default_budget_scen', [this.projectID]) 
+      this.$sciris.rpc('new_scen', [this.projectID])
         .then(response => {
-          this.defaultBudgetScen = response.data // Set the scenario to what we received.
-          this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
-          
-          this.addEditModal.scenSummary.parsetname = this.activeParset
-          this.addEditModal.scenSummary.progsetname = 'None'
-          this.doTestScen()
+          this.new_scen = response.data // Set the scenario to what we received.
+          this.addEditModal.scenSummary = _.cloneDeep(this.new_scen)
+
+          // this.doTestScen()
           
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
@@ -217,7 +215,7 @@ var ScenarioMixin = {
       console.log(this.defaultBudgetScen)
       this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
       
-      this.doTestScen()
+      // this.doTestScen()
       
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -191,25 +191,17 @@ var ScenarioMixin = {
         })          
     },
     
-    initModal() {
-      if (this.addEditModal.scenSummary.progsetname == 'None') {
-        this.addEditModal.scenSummary.scentype = 'parameter'
-      } else {
-        this.addEditModal.scenSummary.scentype = 'budget'
-      }
-    },
-
-    addScenModal() {
+    addScenModal(scentype) {
       console.log('addScenModal() called')
 
       // Get a "template" new scenario from the server.
-      this.$sciris.rpc('new_scen', [this.projectID])
+      this.$sciris.rpc('new_scen', [this.projectID, scentype])
         .then(response => {
           this.new_scen = response.data // Set the scenario to what we received.
           this.addEditModal.scenSummary = _.cloneDeep(this.new_scen)
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
-          this.initModal()
+          this.addEditModal.scenSummary.scentype = scentype  // TODO: remove this
           this.$modal.show('add-edit-scen')
         })
         .catch(error => {
@@ -324,7 +316,6 @@ var ScenarioMixin = {
       this.addEditModal.scenSummary = _.cloneDeep(scenSummary)     
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'
-      this.initModal()
       // Open a model dialog for creating a new project
       this.$modal.show('add-edit-scen');
     },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -67,7 +67,6 @@ var ScenarioMixin = {
             .then(response2 => {
               // The order of execution / completion of these doesn't matter.
               this.getScenSummaries()
-              this.getDefaultBudgetScen()
               this.reloadGraphs(false)
             })
         })
@@ -88,19 +87,6 @@ var ScenarioMixin = {
     reloadGraphs(showErr)             { return this.$sciris.reloadGraphs(this, this.projectID, this.serverDatastoreId, showErr, false, true) }, // Set to calibration=false, plotbudget=true
     maximize(legend_id)               { return this.$sciris.maximize(this, legend_id) },
     minimize(legend_id)               { return this.$sciris.minimize(this, legend_id) },
-
-    getDefaultBudgetScen() {
-      console.log('getDefaultBudgetScen() called')
-      this.$sciris.rpc('get_default_budget_scen', [this.projectID])
-        .then(response => {
-          this.defaultBudgetScen = response.data // Set the scenario to what we received.
-          console.log('This is the default:')
-          console.log(this.defaultBudgetScen);
-        })
-        .catch(error => {
-          this.$sciris.fail(this, 'Could not get default budget scenario', error)
-        })
-    },
     
     getScenSummaries() {
       console.log('getScenSummaries() called')
@@ -131,20 +117,16 @@ var ScenarioMixin = {
     },
 
     addScenModal() {
-      // Open a model dialog for creating a new project
       console.log('addScenModal() called');
-      // TODO: I'm thinking we don't really need this RPC call, since the default budget
-      // scenario gets loaded on creation of the page.
-      // Or, alternatively, we should take the call out of the create() function.
+
+      // Get a "template" new scenario from the server.
       this.$sciris.rpc('new_scen', [this.projectID])
         .then(response => {
           this.new_scen = response.data // Set the scenario to what we received.
           this.addEditModal.scenSummary = _.cloneDeep(this.new_scen)
-          
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
           this.$modal.show('add-edit-scen');
-          console.log(this.defaultBudgetScen)
         })
         .catch(error => {
           this.$sciris.fail(this, 'Could not open add scenario modal', error)

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -137,9 +137,34 @@ var ScenarioMixin = {
     },
     
     changeProgset() {
+      // If we've switched off program sets, change the modal mode to parameters overwrites.
       if (this.addEditModal.scenSummary.progsetname == 'None') {
         this.addEditModal.scenEditMode = 'parameters'
-      }        
+        
+      // Otherwise...
+      } else {
+        this.$sciris.start(this)
+        this.$sciris.rpc('scen_change_progset', [this.addEditModal.scenSummary, this.addEditModal.scenSummary.progsetname, this.projectID])
+          .then(response => {           
+            this.addEditModal.scenSummary = response.data
+            this.$sciris.succeed(this, 'Progset change completed')
+          })
+          .catch(error => {
+            this.$sciris.fail(this, 'Could not properly change the progset', error)
+          })           
+      }
+    },
+    
+    resetToProgbook() {
+      this.$sciris.start(this)
+      this.$sciris.rpc('scen_reset_spending', [this.addEditModal.scenSummary, this.projectID])
+        .then(response => {           
+          this.addEditModal.scenSummary = response.data
+          this.$sciris.succeed(this, 'Spending reset completed')
+        })
+        .catch(error => {
+          this.$sciris.fail(this, 'Could not properly reset the spending', error)
+        })          
     },
     
     initModal() {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -354,6 +354,15 @@ var ScenarioMixin = {
     
     modalAddParameter(selectedParamGroup) {
       console.log('modalAddParameter() called')
+      
+      let newParamOverwrite = {
+        paramname: 'Foo', 
+        paramcodename: 'Foocode', 
+        groupname: selectedParamGroup, 
+        popname: 'Bar', 
+        paramvals: [], 
+      }
+      this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
     },
     
     editScen(scenSummary) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -61,11 +61,6 @@ var ScenarioMixin = {
       (this.$store.state.activeProject.project.hasData) &&
       (this.$store.state.activeProject.project.hasPrograms)) {
       console.log('created() called')
-      this.validSimYears = []
-      for (var year = 2000; 
-        year <= 2035; year++) {
-        this.validSimYears.push(year)
-      }
       this.startYear = this.simStart
       this.endYear = this.simEnd
       this.popOptions = this.activePops
@@ -76,6 +71,7 @@ var ScenarioMixin = {
             .then(response2 => {
               // The order of execution / completion of these doesn't matter.
               this.getScenSummaries()
+              this.getSimParams()
               this.getSpendingBaselines()
               this.reloadGraphs(false)
             })
@@ -142,6 +138,23 @@ var ScenarioMixin = {
         .catch(error => {
           this.$sciris.fail(this, 'Could not get spending baselines', error)
         })      
+    },
+    
+    getSimParams() {
+      console.log('getSimParams() called')
+      this.$sciris.start(this)
+      this.$sciris.rpc('get_sim_params', [this.projectID])
+        .then(response => {
+          this.validSimYears = []
+          for (var year = response.data.sim_start_year; 
+              year <= response.data.sim_end_year; year++) {
+            this.validSimYears.push(year)
+          }
+          this.$sciris.succeed(this, 'Simulation params loaded')
+        })
+        .catch(error => {
+          this.$sciris.fail(this, 'Could not load simulation params', error)
+        })         
     },
     
     changeProgset() {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -378,7 +378,7 @@ var ScenarioMixin = {
         paramname: paramname,
         paramcodename: this.getParamCodeNameFromDisplayName(paramname), 
         groupname: selectedParamGroup, 
-        popname: 'Bar', 
+        popname: this.paramGroups.popnames[0], 
         paramvals: [], // TODO: need to pad for cases where multiple paramyears
       }
       this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -135,6 +135,20 @@ var ScenarioMixin = {
           this.$sciris.fail(this, 'Could not get spending baselines', error)
         })      
     },
+    
+    changeProgset() {
+      if (this.addEditModal.scenSummary.progsetname == 'None') {
+        this.addEditModal.scenEditMode = 'parameters'
+      }        
+    },
+    
+    initModal() {
+      if (this.addEditModal.scenSummary.progsetname == 'None') {
+        this.addEditModal.scenEditMode = 'parameters'
+      } else {
+        this.addEditModal.scenEditMode = 'progbudget'
+      }
+    },
 
     addScenModal() {
       console.log('addScenModal() called');
@@ -146,7 +160,8 @@ var ScenarioMixin = {
           this.addEditModal.scenSummary = _.cloneDeep(this.new_scen)
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
-          this.$modal.show('add-edit-scen');
+          this.initModal()
+          this.$modal.show('add-edit-scen')
         })
         .catch(error => {
           this.$sciris.fail(this, 'Could not open add scenario modal', error)
@@ -221,6 +236,7 @@ var ScenarioMixin = {
       this.addEditModal.scenSummary = _.cloneDeep(scenSummary)     
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'
+      this.initModal()
       // Open a model dialog for creating a new project
       this.$modal.show('add-edit-scen');
     },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -37,8 +37,7 @@ var ScenarioMixin = {
       addEditModal: {
         scenSummary: {},
         origName: '',
-        mode: 'add',
-        scenEditMode: 'parameters'       
+        mode: 'add',     
       },
     }
   },
@@ -154,9 +153,10 @@ var ScenarioMixin = {
     },
     
     changeProgset() {
-      // If we've switched off program sets, change the modal mode to parameters overwrites.
+      // If we've switched off program sets, change the scenario type automatically 
+      // to parameters overwrites.
       if (this.addEditModal.scenSummary.progsetname == 'None') {
-        this.addEditModal.scenEditMode = 'parameters'
+        this.addEditModal.scenSummary.scentype = 'parameter'
         
       // Otherwise...
       } else {
@@ -186,14 +186,14 @@ var ScenarioMixin = {
     
     initModal() {
       if (this.addEditModal.scenSummary.progsetname == 'None') {
-        this.addEditModal.scenEditMode = 'parameters'
+        this.addEditModal.scenSummary.scentype = 'parameter'
       } else {
-        this.addEditModal.scenEditMode = 'progbudget'
+        this.addEditModal.scenSummary.scentype = 'budget'
       }
     },
 
     addScenModal() {
-      console.log('addScenModal() called');
+      console.log('addScenModal() called')
 
       // Get a "template" new scenario from the server.
       this.$sciris.rpc('new_scen', [this.projectID])
@@ -263,8 +263,8 @@ var ScenarioMixin = {
       this.addEditModal.scenSummary.budgetyears.push(newYear)
       
       // For each program, add a null to the end of the list, so we have a blank textbox.
-      for (var i = 0; i < this.addEditModal.scenSummary.progvals.length; i++) {
-        this.addEditModal.scenSummary.progvals[i].budgetvals.push(null)
+      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+        this.addEditModal.scenSummary.progs[i].budgetvals.push(null)
       }      
     },
     
@@ -275,13 +275,45 @@ var ScenarioMixin = {
       this.addEditModal.scenSummary.budgetyears.splice(yearindex, 1)
       
       // For each program, delete all spending values corresponding to that budget year.
-      for (var i = 0; i < this.addEditModal.scenSummary.progvals.length; i++) {
-        this.addEditModal.scenSummary.progvals[i].budgetvals.splice(yearindex, 1)
+      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+        this.addEditModal.scenSummary.progs[i].budgetvals.splice(yearindex, 1)
       }      
-    },    
+    },   
+    
+    modalAddCoverageYear() {
+      console.log('modalAddCoverageYear() called')
+    
+      var newYear
+      // If the coverage years list is non-empty, add a new coverage year which is the maximum 
+      // year already there plus 1.
+      if (this.addEditModal.scenSummary.coverageyears.length > 0) {
+        newYear = Math.max(...this.addEditModal.scenSummary.coverageyears) + 1
+      // Otherwise, make the new year the data_end year.
+      } else {
+        newYear = this.spendingBaselines.data_end
+      }
+      this.addEditModal.scenSummary.coverageyears.push(newYear)
+      
+      // For each program, add a null to the end of the list, so we have a blank textbox.
+      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+        this.addEditModal.scenSummary.progs[i].coveragevals.push(null)
+      }      
+    },
+    
+    modalRemoveCoverageYear(yearindex) {
+      console.log('modalRemoveCoverageYear() called')
+      
+      // Delete the coverage year itself.
+      this.addEditModal.scenSummary.coverageyears.splice(yearindex, 1)
+      
+      // For each program, delete all coverage values corresponding to that coverage year.
+      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+        this.addEditModal.scenSummary.progs[i].coveragevals.splice(yearindex, 1)
+      }      
+    },  
     
     editScen(scenSummary) {
-      console.log('editScen() called');
+      console.log('editScen() called')
       this.addEditModal.scenSummary = _.cloneDeep(scenSummary)     
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'
@@ -293,7 +325,7 @@ var ScenarioMixin = {
     copyScen(scenSummary) {
       console.log('copyScen() called')
       this.$sciris.start(this)
-      var newScen = _.cloneDeep(scenSummary);
+      var newScen = _.cloneDeep(scenSummary)
       var otherNames = []
       this.scenSummaries.forEach(scenSum => {
         otherNames.push(scenSum.name)

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -53,6 +53,9 @@ var ScenarioMixin = {
     projectionYears()     { return utils.projectionYears(this) },
     activePops()   { return utils.activePops(this) },
     placeholders() { return this.$sciris.placeholders(this, 1) },
+    sortedParamOverwrites() {
+      return this.applyParamOverwriteSorting(this.addEditModal.scenSummary.paramoverwrites)
+    },
   },
 
   created() {
@@ -235,7 +238,31 @@ var ScenarioMixin = {
           this.$sciris.fail(this, 'Could not open add scenario modal', error)
         })
     },
-
+    
+    applyParamOverwriteSorting(paramoverwrites) {
+      return this.applyParamOverwriteSorting2(paramoverwrites).slice(0).sort((po1, po2) =>
+        {
+          return (po1.groupname.toLowerCase() > po2.groupname.toLowerCase())
+        }
+      )
+    },
+    
+    applyParamOverwriteSorting2(paramoverwrites) {
+      return this.applyParamOverwriteSorting3(paramoverwrites).slice(0).sort((po1, po2) =>
+        {
+          return (po1.paramname.toLowerCase() > po2.paramname.toLowerCase())
+        }
+      )
+    },
+    
+    applyParamOverwriteSorting3(paramoverwrites) {
+      return paramoverwrites.slice(0).sort((po1, po2) =>
+        {
+          return (po1.popname.toLowerCase() > po2.popname.toLowerCase())
+        }
+      )
+    }, 
+    
     modalSave() {
       console.log('modalSave() called')
       this.$modal.hide('add-edit-scen')

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -352,10 +352,10 @@ var ScenarioMixin = {
       }
       this.addEditModal.scenSummary.paramyears.push(newYear)
       
-      // For each program, add a null to the end of the list, so we have a blank textbox.
-/*      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
-        this.addEditModal.scenSummary.progs[i].paramvals.push(null)
-      } */   
+      // For each parameter overwrite, add a null to the end of the list, so we have a blank textbox.
+      for (var i = 0; i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+        this.addEditModal.scenSummary.paramoverwrites[i].paramvals.push(null)
+      }   
     },
     
     modalRemoveParamYear(yearindex) {
@@ -364,22 +364,29 @@ var ScenarioMixin = {
       // Delete the parameter year itself.
       this.addEditModal.scenSummary.paramyears.splice(yearindex, 1)
       
-      // For each program, delete all coverage values corresponding to that coverage year.
-/*      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
-        this.addEditModal.scenSummary.progs[i].paramvals.splice(yearindex, 1)
-      } */   
+      // For each parameter overwrite, delete all parameter values corresponding to that parameter 
+      // year.
+      for (var i = 0; i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+        this.addEditModal.scenSummary.paramoverwrites[i].paramvals.splice(yearindex, 1)
+      }
     },
     
     modalAddParameter(selectedParamGroup) {
       console.log('modalAddParameter() called')
       
       let paramname = this.paramGroupMembers(selectedParamGroup)[0]
+      let newParamvals = []
+      if (this.addEditModal.scenSummary.paramoverwrites.length > 0) {
+        for (var i = 0; i < this.addEditModal.scenSummary.paramoverwrites[0].paramvals.length; i++) {
+          newParamvals.push(null)
+        }
+      }      
       let newParamOverwrite = {
         paramname: paramname,
         paramcodename: this.getParamCodeNameFromDisplayName(paramname), 
         groupname: selectedParamGroup, 
         popname: this.paramGroups.popnames[0], 
-        paramvals: [], // TODO: need to pad for cases where multiple paramyears
+        paramvals: newParamvals,
       }
       this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
     },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -6,8 +6,7 @@ var ScenarioMixin = {
       activeParset:  -1,
       activeProgset: -1,
       parsetOptions: [],
-      progsetOptions: [],
-      selectedProgset: 'None',
+      progsetOptions: [],   
 
       // Plotting data
       showPlotControls: false,
@@ -35,7 +34,9 @@ var ScenarioMixin = {
         scenSummary: {},
         origName: '',
         mode: 'add',
-        scenEditMode: 'parameters'
+        selectedParset: 'default',
+        selectedProgset: 'default',
+        scenEditMode: 'parameters'       
       },
     }
   },
@@ -131,16 +132,16 @@ var ScenarioMixin = {
         })
     },
 
-    addBudgetScenModal() {
+    addScenModal() {
       // Open a model dialog for creating a new project
-      console.log('addBudgetScenModal() called');
+      console.log('addScenModal() called');
       this.$sciris.rpc('get_default_budget_scen', [this.projectID])
         .then(response => {
           this.defaultBudgetScen = response.data // Set the scenario to what we received.
           this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
-          this.$modal.show('add-budget-scen');
+          this.$modal.show('add-edit-scen');
           console.log(this.defaultBudgetScen)
         })
         .catch(error => {
@@ -148,9 +149,9 @@ var ScenarioMixin = {
         })
     },
 
-    addBudgetScen() {
-      console.log('addBudgetScen() called')
-      this.$modal.hide('add-budget-scen')
+    modalSave() {
+      console.log('modalSave() called')
+      this.$modal.hide('add-edit-scen')
       this.$sciris.start(this)
       let newScen = _.cloneDeep(this.addEditModal.scenSummary) // Get the new scenario summary from the modal.
       let scenNames = [] // Get the list of all of the current scenario names.
@@ -175,10 +176,10 @@ var ScenarioMixin = {
       console.log(this.scenSummaries)
       this.$sciris.rpc('set_scen_info', [this.projectID, this.scenSummaries])
         .then( response => {
-          this.$sciris.succeed(this, 'Scenario added')
+          this.$sciris.succeed(this, 'Scenario saved')
         })
         .catch(error => {
-          this.$sciris.fail(this, 'Could not add scenario', error)
+          this.$sciris.fail(this, 'Could not save scenario', error)
         })
     },
 
@@ -191,7 +192,7 @@ var ScenarioMixin = {
       this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'
-      this.$modal.show('add-budget-scen');
+      this.$modal.show('add-edit-scen');
     },
 
     copyScen(scenSummary) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -244,9 +244,16 @@ var ScenarioMixin = {
     
     modalAddBudgetYear() {
       console.log('modalAddBudgetYear() called')
-      
-      // Add a new budget year which is the maximum year already there plus 1.
-      let newYear = Math.max(...this.addEditModal.scenSummary.budgetyears) + 1
+    
+      var newYear
+      // If the budget years list is non-empty, add a new budget year which is the maximum 
+      // year already there plus 1.
+      if (this.addEditModal.scenSummary.budgetyears.length > 0) {
+        newYear = Math.max(...this.addEditModal.scenSummary.budgetyears) + 1
+      // Otherwise, make the new year the data_end year.
+      } else {
+        newYear = this.spendingBaselines.data_end
+      }
       this.addEditModal.scenSummary.budgetyears.push(newYear)
       
       // For each program, add a null to the end of the list, so we have a blank textbox.

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -352,7 +352,8 @@ var ScenarioMixin = {
       } */   
     },
     
-    modalAddParameter() {
+    modalAddParameter(selectedParamGroup) {
+      console.log('modalAddParameter() called')
     },
     
     editScen(scenSummary) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -171,6 +171,31 @@ var ScenarioMixin = {
         })
     },
     
+    modalAddBudgetYear() {
+      console.log('modalAddBudgetYear() called')
+      
+      // Add a new budget year which is the maximum year already there plus 1.
+      let newYear = Math.max(...this.addEditModal.scenSummary.budgetyears) + 1
+      this.addEditModal.scenSummary.budgetyears.push(newYear)
+      
+      // For each program, add a null to the end of the list, so we have a blank textbox.
+      for (var i = 0; i < this.addEditModal.scenSummary.progvals.length; i++) {
+        this.addEditModal.scenSummary.progvals[i].budgetvals.push(null)
+      }      
+    },
+    
+    modalRemoveBudgetYear(yearindex) {
+      console.log('modalRemoveBudgetYear() called')
+      
+      // Delete the budget year itself.
+      this.addEditModal.scenSummary.budgetyears.splice(yearindex, 1)
+      
+      // For each program, delete all spending values corresponding to that budget year.
+      for (var i = 0; i < this.addEditModal.scenSummary.progvals.length; i++) {
+        this.addEditModal.scenSummary.progvals[i].budgetvals.splice(yearindex, 1)
+      }      
+    },    
+    
     editScen(scenSummary) {
       console.log('editScen() called');
       this.addEditModal.scenSummary = _.cloneDeep(scenSummary)     

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -301,7 +301,42 @@ var ScenarioMixin = {
       for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
         this.addEditModal.scenSummary.progs[i].coveragevals.splice(yearindex, 1)
       }      
-    },  
+    }, 
+    
+    modalAddParamYear() {
+      console.log('modalAddParamYear() called')
+    
+      var newYear
+      // If the parameter years list is non-empty, add a new parameter year which is the maximum 
+      // year already there plus 1.
+      if (this.addEditModal.scenSummary.paramyears.length > 0) {
+        newYear = Math.max(...this.addEditModal.scenSummary.paramyears) + 1
+      // Otherwise, make the new year the data_end year.
+      } else {
+        newYear = this.spendingBaselines.data_end
+      }
+      this.addEditModal.scenSummary.paramyears.push(newYear)
+      
+      // For each program, add a null to the end of the list, so we have a blank textbox.
+/*      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+        this.addEditModal.scenSummary.progs[i].paramvals.push(null)
+      } */   
+    },
+    
+    modalRemoveParamYear(yearindex) {
+      console.log('modalRemoveParamYear() called')
+      
+      // Delete the coverage year itself.
+      this.addEditModal.scenSummary.paramyears.splice(yearindex, 1)
+      
+      // For each program, delete all coverage values corresponding to that coverage year.
+/*      for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+        this.addEditModal.scenSummary.progs[i].paramvals.splice(yearindex, 1)
+      } */   
+    },
+    
+    modalAddParameter() {
+    },
     
     editScen(scenSummary) {
       console.log('editScen() called')

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -117,7 +117,15 @@ var ScenarioMixin = {
         }
       }  
       return members
-    },    
+    },
+    
+    getParamCodeNameFromDisplayName(displayname) {
+      for (var ind = 0; ind < this.paramGroups.displaynames.length; ind++) {         
+        if (this.paramGroups.displaynames[ind] == displayname) {
+          return this.paramGroups.codenames[ind]
+        }
+      }          
+    },
     
     getScenSummaries() {
       console.log('getScenSummaries() called')
@@ -365,12 +373,13 @@ var ScenarioMixin = {
     modalAddParameter(selectedParamGroup) {
       console.log('modalAddParameter() called')
       
+      let paramname = this.paramGroupMembers(selectedParamGroup)[0]
       let newParamOverwrite = {
-        paramname: this.paramGroupMembers(selectedParamGroup)[0],
-        paramcodename: 'Foocode', 
+        paramname: paramname,
+        paramcodename: this.getParamCodeNameFromDisplayName(paramname), 
         groupname: selectedParamGroup, 
         popname: 'Bar', 
-        paramvals: [], 
+        paramvals: [], // TODO: need to pad for cases where multiple paramyears
       }
       this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
     },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -29,6 +29,7 @@ var ScenarioMixin = {
       // Page-specific data
       scenSummaries: [],
       spendingBaselines: {},
+      validProgramStartYears: [],
       scenariosLoaded: false,
       addEditModal: {
         scenSummary: {},
@@ -123,6 +124,11 @@ var ScenarioMixin = {
       this.$sciris.rpc('get_baseline_spending', [this.projectID])
         .then(response => {
           this.spendingBaselines = response.data // Set the spending baselines to what we received.
+          this.validProgramStartYears = []
+          for (var year = this.spendingBaselines.data_start; 
+            year <= this.spendingBaselines.data_end + 10; year++) {
+              this.validProgramStartYears.push(year)
+          }
           this.$sciris.succeed(this, 'Spending baselines loaded')
         })
         .catch(error => {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -109,6 +109,16 @@ var ScenarioMixin = {
     maximize(legend_id)               { return this.$sciris.maximize(this, legend_id) },
     minimize(legend_id)               { return this.$sciris.minimize(this, legend_id) },
     
+    paramGroupMembers(groupname) { 
+      let members = []
+      for (var ind = 0; ind < this.paramGroups.codenames.length; ind++) {
+        if (this.paramGroups.groupnames[ind] == groupname) {
+          members.push(this.paramGroups.displaynames[ind])
+        }
+      }  
+      return members
+    },    
+    
     getScenSummaries() {
       console.log('getScenSummaries() called')
       this.$sciris.start(this)
@@ -356,7 +366,7 @@ var ScenarioMixin = {
       console.log('modalAddParameter() called')
       
       let newParamOverwrite = {
-        paramname: 'Foo', 
+        paramname: this.paramGroupMembers(selectedParamGroup)[0],
         paramcodename: 'Foocode', 
         groupname: selectedParamGroup, 
         popname: 'Bar', 

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -96,7 +96,13 @@ var ScenarioMixin = {
     reloadGraphs(showErr)             { 
       utils.validateYears(this);
       // Set to calibration=false, plotbudget=true
-      return utils.reloadGraphs(this, this.projectID, this.serverDatastoreId, showErr, false, true) 
+      return utils.reloadGraphs(
+        this,
+        this.projectID,
+        this.serverDatastoreId,
+        showErr,
+        false,
+        true)
     }, 
     maximize(legend_id)               { return this.$sciris.maximize(this, legend_id) },
     minimize(legend_id)               { return this.$sciris.minimize(this, legend_id) },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -7,6 +7,7 @@ var ScenarioMixin = {
       activeProgset: -1,
       parsetOptions: [],
       progsetOptions: [],
+      selectedProgset: 'None',
 
       // Plotting data
       showPlotControls: false,
@@ -34,7 +35,7 @@ var ScenarioMixin = {
         scenSummary: {},
         origName: '',
         mode: 'add',
-        scenEditMode: 'progbudget'
+        scenEditMode: 'parameters'
       },
     }
   },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -361,7 +361,7 @@ var ScenarioMixin = {
     modalRemoveParamYear(yearindex) {
       console.log('modalRemoveParamYear() called')
       
-      // Delete the coverage year itself.
+      // Delete the parameter year itself.
       this.addEditModal.scenSummary.paramyears.splice(yearindex, 1)
       
       // For each program, delete all coverage values corresponding to that coverage year.
@@ -382,6 +382,16 @@ var ScenarioMixin = {
         paramvals: [], // TODO: need to pad for cases where multiple paramyears
       }
       this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
+    },
+    
+    modalDeleteParameter(paramoverwrite) {
+      console.log('modalDeleteParameter() called')
+      for (var i = 0; i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+        if ((this.addEditModal.scenSummary.paramoverwrites[i].paramname === paramoverwrite.paramname) && 
+            (this.addEditModal.scenSummary.paramoverwrites[i].popname === paramoverwrite.popname)) {
+          this.addEditModal.scenSummary.paramoverwrites.splice(i, 1);
+        }
+      }        
     },
     
     editScen(scenSummary) {
@@ -415,8 +425,8 @@ var ScenarioMixin = {
     deleteScen(scenSummary) {
       console.log('deleteScen() called')
       this.$sciris.start(this)
-      for(var i = 0; i< this.scenSummaries.length; i++) {
-        if(this.scenSummaries[i].name === scenSummary.name) {
+      for (var i = 0; i< this.scenSummaries.length; i++) {
+        if (this.scenSummaries[i].name === scenSummary.name) {
           this.scenSummaries.splice(i, 1);
         }
       }

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -119,8 +119,7 @@ var ScenarioMixin = {
           budgetvals: ['25,568,000', '25,568,000', '25,568,000'],
           coveragevals: ['95', null, null]
       }
-      this.addEditModal.scenSummary.progvals.push(prog)
-//      this.addEditModal.scenSummary.progvals.budgetvals = [1.00, 2.11, 3.22]        
+      this.addEditModal.scenSummary.progvals.push(prog)      
     },
 
     getScenSummaries() {
@@ -154,11 +153,16 @@ var ScenarioMixin = {
     addScenModal() {
       // Open a model dialog for creating a new project
       console.log('addScenModal() called');
-      this.$sciris.rpc('get_default_budget_scen', [this.projectID])
+      // TODO: I'm thinking we don't really need this RPC call, since the default budget
+      // scenario gets loaded on creation of the page.
+      // Or, alternatively, we should take the call out of the create() function.
+      this.$sciris.rpc('get_default_budget_scen', [this.projectID]) 
         .then(response => {
           this.defaultBudgetScen = response.data // Set the scenario to what we received.
           this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
           
+          this.addEditModal.scenSummary.parsetname = this.activeParset
+          this.addEditModal.scenSummary.progsetname = 'None'
           this.doTestScen()
           
           this.addEditModal.origName = this.addEditModal.scenSummary.name

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -31,6 +31,7 @@ var ScenarioMixin = {
       // Page-specific data
       scenSummaries: [],
       spendingBaselines: {},
+      paramGroups: {}, 
       validProgramStartYears: [],
       validSimYears: [],
       scenariosLoaded: false,
@@ -75,6 +76,7 @@ var ScenarioMixin = {
               // The order of execution / completion of these doesn't matter.
               this.getScenSummaries()
               this.getSpendingBaselines()
+              this.getParamGroups()
               this.reloadGraphs(false)
             })
         })
@@ -151,6 +153,19 @@ var ScenarioMixin = {
           this.$sciris.fail(this, 'Could not get spending baselines', error)
         })      
     },
+    
+    getParamGroups() {
+      console.log('getParamGroups() called')
+      this.$sciris.start(this)
+      this.$sciris.rpc('get_param_groups', [this.projectID])
+        .then(response => {
+          this.paramGroups = response.data // Set the parameter groups to what we received.
+          this.$sciris.succeed(this, 'Parameter groups loaded')
+        })
+        .catch(error => {
+          this.$sciris.fail(this, 'Could not get parameter groups', error)
+        })      
+    }, 
     
     changeProgset() {
       // If we've switched off program sets, change the scenario type automatically 

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -207,15 +207,15 @@ var ScenarioMixin = {
       }
     },
     
-    resetToProgbook() {
+    resetToDefaultValues() {
       this.$sciris.start(this)
-      this.$sciris.rpc('scen_reset_spending', [this.addEditModal.scenSummary, this.projectID])
+      this.$sciris.rpc('scen_reset_values', [this.addEditModal.scenSummary, this.projectID])
         .then(response => {           
           this.addEditModal.scenSummary = response.data
-          this.$sciris.succeed(this, 'Spending reset completed')
+          this.$sciris.succeed(this, 'Value reset completed')
         })
         .catch(error => {
-          this.$sciris.fail(this, 'Could not properly reset the spending', error)
+          this.$sciris.fail(this, 'Could not properly reset the values', error)
         })          
     },
     

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -112,6 +112,11 @@ var ScenarioMixin = {
       this.$sciris.rpc('get_scen_info', [this.projectID])
         .then(response => {
           this.scenSummaries = response.data // Set the scenarios to what we received.
+          // TODO: delete this extra code that fills in budget scenario types for all scenarios.
+          this.scenSummaries.forEach(scenSum => {
+            scenSum.scentype = 'budget'
+          })
+      
           console.log('Scenario summaries:')
           console.log(this.scenSummaries)
           this.scenariosLoaded = true
@@ -164,6 +169,7 @@ var ScenarioMixin = {
         this.$sciris.rpc('scen_change_progset', [this.addEditModal.scenSummary, this.addEditModal.scenSummary.progsetname, this.projectID])
           .then(response => {           
             this.addEditModal.scenSummary = response.data
+            this.addEditModal.scenSummary.scentype = 'budget'  // TODO: remove this
             this.$sciris.succeed(this, 'Progset change completed')
           })
           .catch(error => {
@@ -177,6 +183,7 @@ var ScenarioMixin = {
       this.$sciris.rpc('scen_reset_spending', [this.addEditModal.scenSummary, this.projectID])
         .then(response => {           
           this.addEditModal.scenSummary = response.data
+          this.addEditModal.scenSummary.scentype = 'budget'  // TODO: remove this
           this.$sciris.succeed(this, 'Spending reset completed')
         })
         .catch(error => {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -33,7 +33,8 @@ var ScenarioMixin = {
       addEditModal: {
         scenSummary: {},
         origName: '',
-        mode: 'add'
+        mode: 'add',
+        scenEditMode: 'progbudget'
       },
     }
   },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -102,26 +102,6 @@ var ScenarioMixin = {
         })
     },
     
-    doTestScen() {
-      this.addEditModal.scenSummary.budgetyears = [2017, 2018, 2019]
-      this.addEditModal.scenSummary.coverageyears = [2017, 2018, 2019]
-      this.addEditModal.scenSummary.progvals = []
-      let prog = {
-          name: 'BCG vaccination',
-          shortname: 'BCG', 
-          budgetvals: ['345,000', null, null],
-          coveragevals: ['95', null, null]
-      }
-      this.addEditModal.scenSummary.progvals.push(prog)
-      prog = {
-          name: 'Passive case finding',
-          shortname: 'PCF', 
-          budgetvals: ['25,568,000', '25,568,000', '25,568,000'],
-          coveragevals: ['95', null, null]
-      }
-      this.addEditModal.scenSummary.progvals.push(prog)      
-    },
-
     getScenSummaries() {
       console.log('getScenSummaries() called')
       this.$sciris.start(this)
@@ -160,8 +140,6 @@ var ScenarioMixin = {
         .then(response => {
           this.new_scen = response.data // Set the scenario to what we received.
           this.addEditModal.scenSummary = _.cloneDeep(this.new_scen)
-
-          // this.doTestScen()
           
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
@@ -187,6 +165,10 @@ var ScenarioMixin = {
         if (index > -1) {
           this.scenSummaries[index].name = newScen.name  // hack to make sure Vue table updated
           this.scenSummaries[index] = newScen
+          
+          // Hack to get the Vue display of scenSummaries to update
+          this.scenSummaries.push(this.scenSummaries[0])
+          this.scenSummaries.pop()          
         }
         else {
           console.log('Error: a mismatch in editing keys')
@@ -208,17 +190,11 @@ var ScenarioMixin = {
     },
     
     editScen(scenSummary) {
-      // Open a model dialog for creating a new project
       console.log('editScen() called');
-      this.defaultBudgetScen = scenSummary
-      console.log('defaultBudgetScen')
-      console.log(this.defaultBudgetScen)
-      this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
-      
-      // this.doTestScen()
-      
+      this.addEditModal.scenSummary = _.cloneDeep(scenSummary)     
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'
+      // Open a model dialog for creating a new project
       this.$modal.show('add-edit-scen');
     },
 

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -104,17 +104,20 @@ var ScenarioMixin = {
     
     doTestScen() {
       this.addEditModal.scenSummary.budgetyears = [2017, 2018, 2019]
+      this.addEditModal.scenSummary.coverageyears = [2017, 2018, 2019]
       this.addEditModal.scenSummary.progvals = []
       let prog = {
           name: 'BCG vaccination',
           shortname: 'BCG', 
-          budgetvals: ['345,000', '345,000', '345,000']
+          budgetvals: ['345,000', null, null],
+          coveragevals: ['95', null, null]
       }
       this.addEditModal.scenSummary.progvals.push(prog)
       prog = {
           name: 'Passive case finding',
           shortname: 'PCF', 
-          budgetvals: ['25,568,000', '25,568,000', '25,568,000']
+          budgetvals: ['25,568,000', '25,568,000', '25,568,000'],
+          coveragevals: ['95', null, null]
       }
       this.addEditModal.scenSummary.progvals.push(prog)
 //      this.addEditModal.scenSummary.progvals.budgetvals = [1.00, 2.11, 3.22]        

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -34,8 +34,6 @@ var ScenarioMixin = {
         scenSummary: {},
         origName: '',
         mode: 'add',
-        selectedParset: 'default',
-        selectedProgset: 'default',
         scenEditMode: 'parameters'       
       },
     }
@@ -103,6 +101,24 @@ var ScenarioMixin = {
           this.$sciris.fail(this, 'Could not get default budget scenario', error)
         })
     },
+    
+    doTestScen() {
+      this.addEditModal.scenSummary.budgetyears = [2017, 2018, 2019]
+      this.addEditModal.scenSummary.progvals = []
+      let prog = {
+          name: 'BCG vaccination',
+          shortname: 'BCG', 
+          budgetvals: ['345,000', '345,000', '345,000']
+      }
+      this.addEditModal.scenSummary.progvals.push(prog)
+      prog = {
+          name: 'Passive case finding',
+          shortname: 'PCF', 
+          budgetvals: ['25,568,000', '25,568,000', '25,568,000']
+      }
+      this.addEditModal.scenSummary.progvals.push(prog)
+//      this.addEditModal.scenSummary.progvals.budgetvals = [1.00, 2.11, 3.22]        
+    },
 
     getScenSummaries() {
       console.log('getScenSummaries() called')
@@ -139,6 +155,9 @@ var ScenarioMixin = {
         .then(response => {
           this.defaultBudgetScen = response.data // Set the scenario to what we received.
           this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
+          
+          this.doTestScen()
+          
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
           this.$modal.show('add-edit-scen');
@@ -182,7 +201,7 @@ var ScenarioMixin = {
           this.$sciris.fail(this, 'Could not save scenario', error)
         })
     },
-
+    
     editScen(scenSummary) {
       // Open a model dialog for creating a new project
       console.log('editScen() called');
@@ -190,6 +209,9 @@ var ScenarioMixin = {
       console.log('defaultBudgetScen')
       console.log(this.defaultBudgetScen)
       this.addEditModal.scenSummary = _.cloneDeep(this.defaultBudgetScen)
+      
+      this.doTestScen()
+      
       this.addEditModal.origName = this.addEditModal.scenSummary.name
       this.addEditModal.mode = 'edit'
       this.$modal.show('add-edit-scen');

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -111,12 +111,7 @@ var ScenarioMixin = {
       this.$sciris.start(this)
       this.$sciris.rpc('get_scen_info', [this.projectID])
         .then(response => {
-          this.scenSummaries = response.data // Set the scenarios to what we received.
-          // TODO: delete this extra code that fills in budget scenario types for all scenarios.
-          this.scenSummaries.forEach(scenSum => {
-            scenSum.scentype = 'budget'
-          })
-      
+          this.scenSummaries = response.data // Set the scenarios to what we received.      
           console.log('Scenario summaries:')
           console.log(this.scenSummaries)
           this.scenariosLoaded = true
@@ -169,7 +164,6 @@ var ScenarioMixin = {
         this.$sciris.rpc('scen_change_progset', [this.addEditModal.scenSummary, this.addEditModal.scenSummary.progsetname, this.projectID])
           .then(response => {           
             this.addEditModal.scenSummary = response.data
-            this.addEditModal.scenSummary.scentype = 'budget'  // TODO: remove this
             this.$sciris.succeed(this, 'Progset change completed')
           })
           .catch(error => {
@@ -183,7 +177,6 @@ var ScenarioMixin = {
       this.$sciris.rpc('scen_reset_spending', [this.addEditModal.scenSummary, this.projectID])
         .then(response => {           
           this.addEditModal.scenSummary = response.data
-          this.addEditModal.scenSummary.scentype = 'budget'  // TODO: remove this
           this.$sciris.succeed(this, 'Spending reset completed')
         })
         .catch(error => {
@@ -201,7 +194,6 @@ var ScenarioMixin = {
           this.addEditModal.scenSummary = _.cloneDeep(this.new_scen)
           this.addEditModal.origName = this.addEditModal.scenSummary.name
           this.addEditModal.mode = 'add'
-          this.addEditModal.scenSummary.scentype = scentype  // TODO: remove this
           this.$modal.show('add-edit-scen')
         })
         .catch(error => {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -28,7 +28,7 @@ var ScenarioMixin = {
 
       // Page-specific data
       scenSummaries: [],
-      defaultBudgetScen: {},
+      spendingBaselines: {},
       scenariosLoaded: false,
       addEditModal: {
         scenSummary: {},
@@ -122,7 +122,7 @@ var ScenarioMixin = {
       this.$sciris.start(this)
       this.$sciris.rpc('get_baseline_spending', [this.projectID])
         .then(response => {
-          this.xxx = response.data // Set the xxx to what we received.
+          this.spendingBaselines = response.data // Set the spending baselines to what we received.
           this.$sciris.succeed(this, 'Spending baselines loaded')
         })
         .catch(error => {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -67,6 +67,7 @@ var ScenarioMixin = {
             .then(response2 => {
               // The order of execution / completion of these doesn't matter.
               this.getScenSummaries()
+              this.getSpendingBaselines()
               this.reloadGraphs(false)
             })
         })
@@ -114,6 +115,19 @@ var ScenarioMixin = {
         .catch(error => {
           this.$sciris.fail(this, 'Could not save scenarios', error)
         })
+    },
+    
+    getSpendingBaselines() {
+      console.log('getSpendingBaselines() called')
+      this.$sciris.start(this)
+      this.$sciris.rpc('get_baseline_spending', [this.projectID])
+        .then(response => {
+          this.xxx = response.data // Set the xxx to what we received.
+          this.$sciris.succeed(this, 'Spending baselines loaded')
+        })
+        .catch(error => {
+          this.$sciris.fail(this, 'Could not get spending baselines', error)
+        })      
     },
 
     addScenModal() {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -38,7 +38,8 @@ var ScenarioMixin = {
       addEditModal: {
         scenSummary: {},
         origName: '',
-        mode: 'add',     
+        mode: 'add',  
+        selectedParamGroup: '',        
       },
     }
   },
@@ -160,6 +161,7 @@ var ScenarioMixin = {
       this.$sciris.rpc('get_param_groups', [this.projectID])
         .then(response => {
           this.paramGroups = response.data // Set the parameter groups to what we received.
+          this.addEditModal.selectedParamGroup = this.paramGroups.grouplist[0]
           this.$sciris.succeed(this, 'Parameter groups loaded')
         })
         .catch(error => {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -272,7 +272,7 @@ function reloadGraphs(vm, project_id, cache_id, showNoCacheError, iscalibration,
   ], {
     tool: vm.toolName(), 
     'cascade': null, 
-    plotyear: vm.endYear, 
+    plotyear: vm.simEndYear, 
     pops: vm.activePop, 
     calibration: iscalibration, 
     plotbudget: plotbudget

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2018-10-05
+Last update: 2019-03-18
 -->
 
 <template>
@@ -120,7 +120,7 @@ Last update: 2018-10-05
             <div>
 
               <b>Year: &nbsp;</b>
-              <select v-model="endYear" @change="reloadGraphs(true)">
+              <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in simYears'>
                   {{ year }}
                 </option>

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2018-09-26
+Last update: 2019-03-18
 -->
 
 <template>
@@ -77,7 +77,7 @@ Last update: 2018-09-26
             <div>
 
               <b>Year: &nbsp;</b>
-              <select v-model="endYear" @change="reloadGraphs(displayResultDatastoreId, true)">
+              <select v-model="simEndYear" @change="reloadGraphs(displayResultDatastoreId, true)">
                 <option v-for='year in projectionYears'>
                   {{ year }}
                 </option>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-22
+Last update: 2019-03-23
 -->
 
 <template>
@@ -35,6 +35,7 @@ Last update: 2019-03-22
           <tr>
             <th>Name</th>
             <th>Active</th>
+            <th>Type</th>
             <th>Actions</th>
           </tr>
           </thead>
@@ -45,6 +46,9 @@ Last update: 2019-03-22
             </td>
             <td style="text-align: center">
               <input type="checkbox" v-model="scenSummary.active"/>
+            </td>
+            <td>
+              {{ scenSummary.scentype }}
             </td>
             <td style="white-space: nowrap">
               <button class="btn btn-icon" @click="editScen(scenSummary)" data-tooltip="Edit scenario"><i class="ti-pencil"></i></button>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -218,7 +218,16 @@ Last update: 2019-03-01
                  class="txbox"
                  v-model="addEditModal.scenSummary.alloc_year"/><br>
                  
-          [Parameters, Programs budget, Programs coverage buttons...]<br><br>
+          <div style="display:inline-block; padding-right:10px">
+            <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>
+          </div>
+          <div style="display:inline-block; padding-right:10px">
+            <button class="btn __blue" @click="addEditModal.scenEditMode='progbudget'" data-tooltip="Edit programs budget">Programs budget</button>
+          </div>
+          <div style="display:inline-block; padding-right:10px">
+            <button class="btn __blue" @click="addEditModal.scenEditMode='progcoverage'" data-tooltip="Edit programs coverage">Programs coverage</button>
+          </div>
+          <br><br>
           
           <div v-if="addEditModal.scenEditMode == 'parameters'">
             Crazy parametric foofah!...<br>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -253,7 +253,6 @@ Last update: 2019-03-14
                 </tr>                
                 <tr>
                   <th>Program</th>
-                  <th>Baseline in {{ addEditModal.scenSummary.program_start_year }}</th>
                   <th v-for="(val, index) in addEditModal.scenSummary.budgetyears">
                     <input type="text"
                            class="txbox"
@@ -272,9 +271,6 @@ Last update: 2019-03-14
                 </thead>
                 <tbody>
                 <tr v-for="prog in addEditModal.scenSummary.progvals">
-                  <td>
-                    {{ prog.name }}
-                  </td>
                   <td>
                     {{ prog.name }}
                   </td>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-03
+Last update: 2019-04-04
 -->
 
 <template>
@@ -235,9 +235,9 @@ Last update: 2019-04-03
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
             <b>Parameter group</b><br>
-            <select @change="changeProgset()" v-model="addEditModal.scenSummary.progsetname">
-              <option v-for='progset in progsetOptions'>
-                {{ progset }}
+            <select v-model="addEditModal.selectedParamGroup">
+              <option v-for='group in paramGroups.grouplist'>
+                {{ group }}
               </option>
             </select><br><br>
           </div>   

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-08
+Last update: 2019-04-10
 -->
 
 <template>
@@ -267,17 +267,14 @@ Last update: 2019-04-08
                         {{ year }}
                       </option>
                     </select> 
-                    <button @click="modalRemoveBudgetYear(index)" class='btn __red' style="display:inline-block">
-                      X
+                    <button @click="modalRemoveBudgetYear(index)" class='btn-small' style="display:inline-block">
+                      <i class="ti-trash"></i>
                     </button>         
                   </th>                  
                   <th>
-                    <button @click="modalAddBudgetYear()" class='btn __green' style="display:inline-block">
+                    <button @click="modalAddBudgetYear()" class='btn-small' style="display:inline-block">
                       +
-                    </button>
-                    <button @click="resetToProgbook()" class='btn __red' style="display:inline-block">
-                      Reset to progbook
-                    </button>                                        
+                    </button>                                    
                   </th>
                 </tr>
                 </thead>
@@ -317,17 +314,14 @@ Last update: 2019-04-08
                         {{ year }}
                       </option>
                     </select> 
-                    <button @click="modalRemoveCoverageYear(index)" class='btn __red' style="display:inline-block">
-                      X
+                    <button @click="modalRemoveCoverageYear(index)" class='btn_small' style="display:inline-block">
+                      <i class="ti-trash"></i>
                     </button>         
                   </th>                  
                   <th>
-                    <button @click="modalAddCoverageYear()" class='btn __green' style="display:inline-block">
+                    <button @click="modalAddCoverageYear()" class='btn_small' style="display:inline-block">
                       +
-                    </button>
-                    <button @click="resetToProgbook()" class='btn __red' style="display:inline-block">
-                      Reset to progbook
-                    </button>                                        
+                    </button>                                       
                   </th>
                 </tr>
                 </thead>
@@ -367,12 +361,12 @@ Last update: 2019-04-08
                         {{ year }}
                       </option>
                     </select> 
-                    <button @click="modalRemoveParamYear(index)" class='btn __red' style="display:inline-block">
-                      X
+                    <button @click="modalRemoveParamYear(index)" class='btn_small' style="display:inline-block">
+                      <i class="ti-trash"></i>
                     </button>         
                   </th>                  
                   <th>
-                    <button @click="modalAddParamYear()" class='btn __green' style="display:inline-block">
+                    <button @click="modalAddParamYear()" class='btn_small' style="display:inline-block">
                       +
                     </button>                                       
                   </th>
@@ -419,6 +413,9 @@ Last update: 2019-04-08
           <button @click="modalSave()" class='btn __green' style="display:inline-block">
             Save scenario
           </button>
+          <button @click="resetToDefaultValues()" class='btn' style="display:inline-block">
+            Reset to default values
+          </button>          
           <button @click="$modal.hide('add-edit-scen')" class='btn __red' style="display:inline-block">
             Cancel
           </button>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-25
+Last update: 2019-03-26
 -->
 
 <template>
@@ -212,16 +212,17 @@ Last update: 2019-03-25
               </option>
             </select><br><br>
           </div>
-          <div style="display:inline-block; padding-right:10px">
+          <div v-if="addEditModal.scenSummary.scentype != 'parameter'"
+               style="display:inline-block; padding-right:10px">
             <b>Program set</b><br>
             <select @change="changeProgset()" v-model="addEditModal.scenSummary.progsetname">
-              <option>None</option>
               <option v-for='progset in progsetOptions'>
                 {{ progset }}
               </option>
             </select><br><br>
           </div>
-          <div style="display:inline-block; padding-right:10px">
+          <div v-if="addEditModal.scenSummary.scentype != 'parameter'" 
+               style="display:inline-block; padding-right:10px">
             <b>Program start year</b><br>
             <select :disabled="addEditModal.scenSummary.progsetname=='None'"
                     v-model="addEditModal.scenSummary.progstartyear">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-02
+Last update: 2019-03-04
 -->
 
 <template>
@@ -57,7 +57,7 @@ Last update: 2019-03-02
 
         <div>
           <button class="btn __green" :disabled="!scenariosLoaded" @click="runScens()">Run scenarios</button>
-          <button class="btn __blue" :disabled="!scenariosLoaded" @click="addBudgetScenModal()">Add scenario</button>
+          <button class="btn __blue" :disabled="!scenariosLoaded" @click="addScenModal()">Add scenario</button>
         </div>
       </div>
       <!-- ### End: scenarios card ### -->
@@ -177,7 +177,7 @@ Last update: 2019-03-02
 
 
     <!-- ### Start: add scenarios modal ### -->
-    <modal name="add-budget-scen"
+    <modal name="add-edit-scen"
            height="auto"
            :scrollable="true"
            :width="1000"
@@ -200,7 +200,7 @@ Last update: 2019-03-02
                       
           <div style="display:inline-block; padding-right:10px">
             <b>Parameter set</b><br>
-            <select v-model="parsetOptions[0]">
+            <select v-model="addEditModal.selectedParset">
               <option v-for='parset in parsetOptions'>
                 {{ parset }}
               </option>
@@ -208,7 +208,7 @@ Last update: 2019-03-02
           </div>
           <div style="display:inline-block; padding-right:10px">
             <b>Program set</b><br>
-            <select v-model="selectedProgset">
+            <select v-model="addEditModal.selectedProgset">
               <option>None</option>
               <option v-for='progset in progsetOptions'>
                 {{ progset }}
@@ -219,18 +219,18 @@ Last update: 2019-03-02
           <b>Program start year</b><br>
           <input type="text"
                  class="txbox"
-                 :disabled="selectedProgset=='None'"
+                 :disabled="addEditModal.selectedProgset=='None'"
                  v-model="addEditModal.scenSummary.alloc_year"/><br>
           
           <div style="display:inline-block; padding-right:10px">
             <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>
           </div>
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" :disabled="selectedProgset=='None'"
+            <button class="btn __blue" :disabled="addEditModal.selectedProgset=='None'"
             @click="addEditModal.scenEditMode='progbudget'" data-tooltip="Edit programs budget">Programs budget</button>
           </div>
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" :disabled="selectedProgset=='None'" 
+            <button class="btn __blue" :disabled="addEditModal.selectedProgset=='None'" 
             @click="addEditModal.scenEditMode='progcoverage'" data-tooltip="Edit programs coverage">Programs coverage</button>
           </div>
           <br><br>
@@ -240,61 +240,75 @@ Last update: 2019-03-02
           </div>
     
           <div v-if="addEditModal.scenEditMode == 'progbudget'">
-            <table class="table table-bordered table-hover table-striped" style="width: 100%">
-              <thead>
-              <tr>
-                <th>Program</th>
-                <th>Budget</th>
-              </tr>
-              </thead>
-              <tbody>
-              <tr v-for="item in addEditModal.scenSummary.alloc">
-                <td>
-                  {{ item[2] }}
-                </td>
-                <td>
-                  <input type="text"
-                         class="txbox"
-                         v-model="item[1]"
-                         style="text-align: right"
-                  />
-                </td>
-              </tr>
-              </tbody>
-            </table>
+            <div class="scrolltable" style="max-height: 80vh;">
+              <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <thead>
+                <tr>
+                  <th colspan=100><div class="dialog-header">
+                    Program spending
+                  </div></th>
+                </tr>                
+                <tr>
+                  <th>Program</th>
+                  <th>Budget</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr v-for="item in addEditModal.scenSummary.alloc">
+                  <td>
+                    {{ item[2] }}
+                  </td>
+                  <td>
+                    <input type="text"
+                           class="txbox"
+                           v-model="item[1]"
+                           style="text-align: right"
+                    />
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
           
           <div v-if="addEditModal.scenEditMode == 'progcoverage'">
-            <table class="table table-bordered table-hover table-striped" style="width: 100%">
-              <thead>
-              <tr>
-                <th>Program</th>
-                <th>Coverage</th>
-              </tr>
-              </thead>
-              <tbody>
-              <tr v-for="item in addEditModal.scenSummary.alloc">
-                <td>
-                  {{ item[2] }}
-                </td>
-                <td>
-                  <input type="text"
-                         class="txbox"
-                         v-model="item[1]"
-                         style="text-align: right"
-                  />
-                </td>
-              </tr>
-              </tbody>
-            </table>
+            <div class="scrolltable" style="max-height: 80vh;">
+              <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <thead>
+                <tr>
+                  <th colspan=100><div class="dialog-header">
+                    Program coverages (%)
+                  </div></th>
+                </tr>                
+                <tr>
+                  <th>Program</th>
+                  <th>Coverage</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr v-for="item in addEditModal.scenSummary.alloc">
+                  <td>
+                    {{ item[2] }}
+                  </td>
+                  <td>
+                    <input type="text"
+                           class="txbox"
+                           v-model="item[1]"
+                           style="text-align: right"
+                    />
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
           
         </div>
         <div style="text-align:justify">
-          <button @click="addBudgetScen()" class='btn __green' style="display:inline-block">
+          <button @click="modalSave()" class='btn __green' style="display:inline-block">
             Save scenario
           </button>
-          <button @click="$modal.hide('add-budget-scen')" class='btn __red' style="display:inline-block">
+          <button @click="$modal.hide('add-edit-scen')" class='btn __red' style="display:inline-block">
             Cancel
           </button>
         </div>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-01
+Last update: 2019-03-02
 -->
 
 <template>
@@ -180,7 +180,7 @@ Last update: 2019-03-01
     <modal name="add-budget-scen"
            height="auto"
            :scrollable="true"
-           :width="500"
+           :width="1000"
            :classes="['v--modal', 'vue-dialog']"
            :pivot-y="0.3"
            :adaptive="true">
@@ -197,40 +197,46 @@ Last update: 2019-03-01
           <input type="text"
                  class="txbox"
                  v-model="addEditModal.scenSummary.name"/><br>
-                 
-          <!-- TODO: Set these in a row. -->
-          [Set this stuff in a row...]<br>
+                      
+          <div style="display:inline-block; padding-right:10px">
+            <b>Parameter set</b><br>
+            <select v-model="parsetOptions[0]">
+              <option v-for='parset in parsetOptions'>
+                {{ parset }}
+              </option>
+            </select><br><br>
+          </div>
+          <div style="display:inline-block; padding-right:10px">
+            <b>Program set</b><br>
+            <select v-model="selectedProgset">
+              <option>None</option>
+              <option v-for='progset in progsetOptions'>
+                {{ progset }}
+              </option>
+            </select><br><br>
+          </div><br>
           
-          <b>Parameter set</b><br>
-          <select v-model="parsetOptions[0]">
-            <option v-for='parset in parsetOptions'>
-              {{ parset }}
-            </option>
-          </select><br><br>
-          <b>Program set</b><br>
-          <select v-model="progsetOptions[0]">
-            <option v-for='progset in progsetOptions'>
-              {{ progset }}
-            </option>
-          </select><br><br>
           <b>Program start year</b><br>
           <input type="text"
                  class="txbox"
+                 :disabled="selectedProgset=='None'"
                  v-model="addEditModal.scenSummary.alloc_year"/><br>
-                 
+          
           <div style="display:inline-block; padding-right:10px">
             <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>
           </div>
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" @click="addEditModal.scenEditMode='progbudget'" data-tooltip="Edit programs budget">Programs budget</button>
+            <button class="btn __blue" :disabled="selectedProgset=='None'"
+            @click="addEditModal.scenEditMode='progbudget'" data-tooltip="Edit programs budget">Programs budget</button>
           </div>
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" @click="addEditModal.scenEditMode='progcoverage'" data-tooltip="Edit programs coverage">Programs coverage</button>
+            <button class="btn __blue" :disabled="selectedProgset=='None'" 
+            @click="addEditModal.scenEditMode='progcoverage'" data-tooltip="Edit programs coverage">Programs coverage</button>
           </div>
           <br><br>
           
           <div v-if="addEditModal.scenEditMode == 'parameters'">
-            Crazy parametric foofah!...<br>
+            Complicated parameters GUI logic...<br><br>
           </div>
     
           <div v-if="addEditModal.scenEditMode == 'progbudget'">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -254,11 +254,16 @@ Last update: 2019-03-16
                 <tr>
                   <th>Program</th>
                   <th v-for="(val, index) in addEditModal.scenSummary.budgetyears">
+                    <select v-model="addEditModal.scenSummary.budgetyears[index]">
+                      <option v-for='year in validSimYears'>
+                        {{ year }}
+                      </option>
+                    </select>                 
 <!--                    <input type="text"
                            class="txbox"
                            style="text-align: right"
                            v-model="addEditModal.scenSummary.budgetyears[index]"/> --> 
-                    {{ addEditModal.scenSummary.budgetyears[index] }}       
+<!--                    {{ addEditModal.scenSummary.budgetyears[index] }}    -->   
                     <button @click="modalRemoveBudgetYear(index)" class='btn __red' style="display:inline-block">
                       X
                     </button>         

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-06
+Last update: 2019-04-08
 -->
 
 <template>
@@ -404,7 +404,7 @@ Last update: 2019-04-06
                            v-model="paramoverwrite.paramvals[index]"/>
                   </td>
                   <td>
-                    <button class='btn __red'>
+                    <button @click="modalDeleteParameter(paramoverwrite)" class="btn __red">
                       X
                     </button>                   
                   </td>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-04
+Last update: 2019-04-06
 -->
 
 <template>
@@ -381,7 +381,11 @@ Last update: 2019-04-04
                 <tbody>
                 <tr v-for="paramoverwrite in addEditModal.scenSummary.paramoverwrites">
                   <td>
-                    {{ paramoverwrite.paramname }}
+                    <select v-model="paramoverwrite.paramname">
+                      <option v-for="paramname in paramGroupMembers(paramoverwrite.groupname)">
+                        {{ paramname }}
+                      </option>
+                    </select>
                   </td>
                   <td>
                     {{ paramoverwrite.groupname }}

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-06
+Last update: 2019-03-12
 -->
 
 <template>
@@ -250,7 +250,20 @@ Last update: 2019-03-06
                 </tr>                
                 <tr>
                   <th>Program</th>
-                  <th v-for="year in addEditModal.scenSummary.budgetyears">{{ year }}</th>
+                  <th v-for="(val, index) in addEditModal.scenSummary.budgetyears">
+                    <input type="text"
+                           class="txbox"
+                           style="text-align: right"
+                           v-model="addEditModal.scenSummary.budgetyears[index]"/>   
+                    <button @click="modalSave()" class='btn __red' style="display:inline-block">
+                      X
+                    </button>         
+                  </th>                  
+                  <th>
+                    <button @click="modalSave()" class='btn __green' style="display:inline-block">
+                      +
+                    </button>
+                  </th>
                 </tr>
                 </thead>
                 <tbody>
@@ -263,6 +276,8 @@ Last update: 2019-03-06
                            class="txbox"
                            style="text-align: right"
                            v-model="prog.budgetvals[index]"/>
+                  </td>
+                  <td>
                   </td>
                 </tr>
                 </tbody>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-26
+Last update: 2019-04-02
 -->
 
 <template>
@@ -230,7 +230,25 @@ Last update: 2019-03-26
                 {{ year }}
               </option>
             </select><br><br>
-          </div><br>
+          </div>
+          
+          <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
+               style="display:inline-block; padding-right:10px">
+            <b>Parameter group</b><br>
+            <select @change="changeProgset()" v-model="addEditModal.scenSummary.progsetname">
+              <option v-for='progset in progsetOptions'>
+                {{ progset }}
+              </option>
+            </select><br><br>
+          </div>   
+          
+          <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
+               style="display:inline-block; padding-right:10px">
+            <button class="btn __blue" @click="modalAddParameter">
+              Add parameter from group
+            </button><br><br>
+          </div>
+          <br>
           
           <div v-if="addEditModal.scenSummary.scentype == 'budget'">
             <div class="scrolltable" style="max-height: 80vh;">
@@ -331,7 +349,53 @@ Last update: 2019-03-26
           </div>
           
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'">
-            Complicated parameters GUI logic...<br><br>
+<!--            <div v-if="addEditModal.scenSummary.params.length > 0" class="scrolltable" style="max-height: 80vh;"> -->
+            <div v-if="1 == 0" class="scrolltable" style="max-height: 80vh;">            
+              <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <thead>
+                <tr>
+                  <th colspan=100><div class="dialog-header">
+                    Parameter modifications
+                  </div></th>
+                </tr>                
+                <tr>
+                  <th>Parameter</th>
+                  <th>Population</th>
+                  <th v-for="(val, index) in addEditModal.scenSummary.paramyears">
+                    <select v-model="addEditModal.scenSummary.paramyears[index]">
+                      <option v-for='year in validSimYears'>
+                        {{ year }}
+                      </option>
+                    </select> 
+                    <button @click="modalRemoveParamYear(index)" class='btn __red' style="display:inline-block">
+                      X
+                    </button>         
+                  </th>                  
+                  <th>
+                    <button @click="modalAddParamYear()" class='btn __green' style="display:inline-block">
+                      +
+                    </button>                                       
+                  </th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr v-for="param in addEditModal.scenSummary.params">
+                  <td>
+                    {{ param.name }}
+                  </td>
+<!--                  <td v-for="(val, index) in param.coveragevals">
+                    <input type="text"
+                           class="txbox"
+                           style="text-align: right"
+                           v-model="param.coveragevals[index]"/>
+                  </td> -->
+                </tr>
+                <tr>
+                 
+                </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
              
         </div>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-21
+Last update: 2019-03-22
 -->
 
 <template>
@@ -57,7 +57,9 @@ Last update: 2019-03-21
 
         <div>
           <button class="btn __green" :disabled="!scenariosLoaded" @click="runScens()">Run scenarios</button>
-          <button class="btn __blue" :disabled="!scenariosLoaded" @click="addScenModal()">Add scenario</button>
+          <button class="btn __blue" :disabled="!scenariosLoaded" @click="addScenModal('budget')">Add budget scenario</button>
+          <button class="btn __blue" :disabled="!scenariosLoaded" @click="addScenModal('coverage')">Add coverage scenario</button>
+          <button class="btn __blue" :disabled="!scenariosLoaded" @click="addScenModal('parameter')">Add parameter scenario</button>          
         </div>
       </div>
       <!-- ### End: scenarios card ### -->
@@ -224,56 +226,6 @@ Last update: 2019-03-21
               </option>
             </select><br><br>
           </div><br>
-          
-          <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenSummary.scentype == 'budget'">
-              <button class="btn __blue"
-                      :disabled="addEditModal.scenSummary.progsetname=='None'"
-                      @click="addEditModal.scenSummary.scentype='budget'">
-                Budget scenario
-              </button>
-            </div>
-            <div v-else>
-              <button class="btn __bw"
-                      :disabled="addEditModal.scenSummary.progsetname=='None'"
-                      @click="addEditModal.scenSummary.scentype='budget'">
-                Budget scenario
-              </button>            
-            </div>
-          </div>
-          
-          <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenSummary.scentype == 'coverage'">
-              <button class="btn __blue"
-                      :disabled="addEditModal.scenSummary.progsetname=='None'" 
-                      @click="addEditModal.scenSummary.scentype='coverage'">
-                Coverage scenario
-              </button>
-            </div>
-            <div v-else>
-              <button class="btn __bw"
-                      :disabled="addEditModal.scenSummary.progsetname=='None'" 
-                      @click="addEditModal.scenSummary.scentype='coverage'">
-                Coverage scenario
-              </button>            
-            </div>           
-          </div>
-         
-          <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenSummary.scentype == 'parameter'">
-              <button class="btn __blue"
-                      @click="addEditModal.scenSummary.scentype='parameter'">
-                Parameter scenario
-              </button>
-            </div>
-            <div v-else>
-              <button class="btn __bw"
-                      @click="addEditModal.scenSummary.scentype='parameter'">
-                Parameter scenario
-              </button>            
-            </div>
-          </div>
-          <br><br> 
           
           <div v-if="addEditModal.scenSummary.scentype == 'budget'">
             <div class="scrolltable" style="max-height: 80vh;">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -391,7 +391,7 @@ Last update: 2019-04-06
                     {{ paramoverwrite.groupname }}
                   </td>
                   <td>
-                    {{ paramoverwrite.popname }}
+                    {{ paramoverwrite.paramcodename }}
                   </td>                  
                   <td v-for="(val, index) in paramoverwrite.paramvals">
                     <input type="text"

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -349,7 +349,7 @@ Last update: 2019-04-04
           </div>
           
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'">
-            <div v-if="addEditModal.scenSummary.params.length > 0" class="scrolltable" style="max-height: 80vh;">        
+            <div v-if="addEditModal.scenSummary.paramoverwrites.length > 0" class="scrolltable" style="max-height: 80vh;">        
               <table class="table table-bordered table-hover table-striped" style="width: 100%">
                 <thead>
                 <tr>
@@ -379,19 +379,27 @@ Last update: 2019-04-04
                 </tr>
                 </thead>
                 <tbody>
-                <tr v-for="param in addEditModal.scenSummary.params">
+                <tr v-for="paramoverwrite in addEditModal.scenSummary.paramoverwrites">
                   <td>
-                    {{ param.name }}
+                    {{ paramoverwrite.paramname }}
                   </td>
-<!--                  <td v-for="(val, index) in param.coveragevals">
+                  <td>
+                    {{ paramoverwrite.groupname }}
+                  </td>
+                  <td>
+                    {{ paramoverwrite.popname }}
+                  </td>                  
+                  <td v-for="(val, index) in paramoverwrite.paramvals">
                     <input type="text"
                            class="txbox"
                            style="text-align: right"
-                           v-model="param.coveragevals[index]"/>
-                  </td> -->
-                </tr>
-                <tr>
-                 
+                           v-model="paramoverwrite.paramvals[index]"/>
+                  </td>
+                  <td>
+                    <button class='btn __red'>
+                      X
+                    </button>                   
+                  </td>
                 </tr>
                 </tbody>
               </table>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -208,7 +208,7 @@ Last update: 2019-03-14
           </div>
           <div style="display:inline-block; padding-right:10px">
             <b>Program set</b><br>
-            <select v-model="addEditModal.scenSummary.progsetname">
+            <select @change="changeProgset()" v-model="addEditModal.scenSummary.progsetname">
               <option>None</option>
               <option v-for='progset in progsetOptions'>
                 {{ progset }}

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -220,7 +220,7 @@ Last update: 2019-03-06
           <input type="text"
                  class="txbox"
                  :disabled="addEditModal.scenSummary.progsetname=='None'"
-                 v-model="addEditModal.scenSummary.alloc_year"/><br>
+                 v-model="addEditModal.scenSummary.program_start_year"/><br>
           
           <div style="display:inline-block; padding-right:10px">
             <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -244,7 +244,7 @@ Last update: 2019-04-04
           
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" @click="modalAddParameter">
+            <button class="btn __blue" @click="modalAddParameter(addEditModal.selectedParamGroup)">
               Add parameter from group
             </button><br><br>
           </div>
@@ -349,8 +349,7 @@ Last update: 2019-04-04
           </div>
           
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'">
-<!--            <div v-if="addEditModal.scenSummary.params.length > 0" class="scrolltable" style="max-height: 80vh;"> -->
-            <div v-if="1 == 0" class="scrolltable" style="max-height: 80vh;">            
+            <div v-if="addEditModal.scenSummary.params.length > 0" class="scrolltable" style="max-height: 80vh;">        
               <table class="table table-bordered table-hover table-striped" style="width: 100%">
                 <thead>
                 <tr>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-04
+Last update: 2019-03-06
 -->
 
 <template>
@@ -200,7 +200,7 @@ Last update: 2019-03-04
                       
           <div style="display:inline-block; padding-right:10px">
             <b>Parameter set</b><br>
-            <select v-model="addEditModal.selectedParset">
+            <select v-model="addEditModal.scenSummary.parsetname">
               <option v-for='parset in parsetOptions'>
                 {{ parset }}
               </option>
@@ -208,7 +208,7 @@ Last update: 2019-03-04
           </div>
           <div style="display:inline-block; padding-right:10px">
             <b>Program set</b><br>
-            <select v-model="addEditModal.selectedProgset">
+            <select v-model="addEditModal.scenSummary.progsetname">
               <option>None</option>
               <option v-for='progset in progsetOptions'>
                 {{ progset }}
@@ -219,18 +219,18 @@ Last update: 2019-03-04
           <b>Program start year</b><br>
           <input type="text"
                  class="txbox"
-                 :disabled="addEditModal.selectedProgset=='None'"
+                 :disabled="addEditModal.scenSummary.progsetname=='None'"
                  v-model="addEditModal.scenSummary.alloc_year"/><br>
           
           <div style="display:inline-block; padding-right:10px">
             <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>
           </div>
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" :disabled="addEditModal.selectedProgset=='None'"
+            <button class="btn __blue" :disabled="addEditModal.scenSummary.progsetname=='None'"
             @click="addEditModal.scenEditMode='progbudget'" data-tooltip="Edit programs budget">Programs budget</button>
           </div>
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" :disabled="addEditModal.selectedProgset=='None'" 
+            <button class="btn __blue" :disabled="addEditModal.scenSummary.progsetname=='None'" 
             @click="addEditModal.scenEditMode='progcoverage'" data-tooltip="Edit programs coverage">Programs coverage</button>
           </div>
           <br><br>
@@ -250,20 +250,19 @@ Last update: 2019-03-04
                 </tr>                
                 <tr>
                   <th>Program</th>
-                  <th>Budget</th>
+                  <th v-for="year in addEditModal.scenSummary.budgetyears">{{ year }}</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr v-for="item in addEditModal.scenSummary.alloc">
+                <tr v-for="prog in addEditModal.scenSummary.progvals">
                   <td>
-                    {{ item[2] }}
+                    {{ prog.name }}
                   </td>
-                  <td>
+                  <td v-for="(val, index) in prog.budgetvals">
                     <input type="text"
                            class="txbox"
-                           v-model="item[1]"
                            style="text-align: right"
-                    />
+                           v-model="prog.budgetvals[index]"/>
                   </td>
                 </tr>
                 </tbody>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -250,6 +250,7 @@ Last update: 2019-03-12
                 </tr>                
                 <tr>
                   <th>Program</th>
+                  <th>Baseline in {{ addEditModal.scenSummary.program_start_year }}</th>
                   <th v-for="(val, index) in addEditModal.scenSummary.budgetyears">
                     <input type="text"
                            class="txbox"
@@ -268,6 +269,9 @@ Last update: 2019-03-12
                 </thead>
                 <tbody>
                 <tr v-for="prog in addEditModal.scenSummary.progvals">
+                  <td>
+                    {{ prog.name }}
+                  </td>
                   <td>
                     {{ prog.name }}
                   </td>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-02
+Last update: 2019-04-03
 -->
 
 <template>
@@ -360,6 +360,7 @@ Last update: 2019-04-02
                 </tr>                
                 <tr>
                   <th>Parameter</th>
+                  <th>Parameter group</th>
                   <th>Population</th>
                   <th v-for="(val, index) in addEditModal.scenSummary.paramyears">
                     <select v-model="addEditModal.scenSummary.paramyears[index]">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-23
+Last update: 2019-03-25
 -->
 
 <template>
@@ -224,7 +224,7 @@ Last update: 2019-03-23
           <div style="display:inline-block; padding-right:10px">
             <b>Program start year</b><br>
             <select :disabled="addEditModal.scenSummary.progsetname=='None'"
-                    v-model="addEditModal.scenSummary.program_start_year">
+                    v-model="addEditModal.scenSummary.progstartyear">
               <option v-for='year in validProgramStartYears'>
                 {{ year }}
               </option>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-14
+Last update: 2019-03-15
 -->
 
 <template>
@@ -266,6 +266,9 @@ Last update: 2019-03-14
                     <button @click="modalAddBudgetYear()" class='btn __green' style="display:inline-block">
                       +
                     </button>
+                    <button @click="resetToProgbook()" class='btn __red' style="display:inline-block">
+                      Reset to progbook
+                    </button>                                        
                   </th>
                 </tr>
                 </thead>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-12
+Last update: 2019-03-14
 -->
 
 <template>
@@ -214,13 +214,16 @@ Last update: 2019-03-12
                 {{ progset }}
               </option>
             </select><br><br>
+          </div>
+          <div style="display:inline-block; padding-right:10px">
+            <b>Program start year</b><br>
+            <select :disabled="addEditModal.scenSummary.progsetname=='None'"
+                    v-model="addEditModal.scenSummary.program_start_year">
+              <option v-for='year in validProgramStartYears'>
+                {{ year }}
+              </option>
+            </select><br><br>
           </div><br>
-          
-          <b>Program start year</b><br>
-          <input type="text"
-                 class="txbox"
-                 :disabled="addEditModal.scenSummary.progsetname=='None'"
-                 v-model="addEditModal.scenSummary.program_start_year"/><br>
           
           <div style="display:inline-block; padding-right:10px">
             <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -226,15 +226,58 @@ Last update: 2019-03-16
           </div><br>
           
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" @click="addEditModal.scenEditMode='parameters'" data-tooltip="Edit parameter dynamics">Parameters</button>
+            <div v-if="addEditModal.scenEditMode == 'parameters'">
+              <button class="btn __blue"
+                      @click="addEditModal.scenEditMode='parameters'"
+                      data-tooltip="Edit parameter dynamics">
+                Parameters
+              </button>
+            </div>
+            <div v-else>
+              <button class="btn __bw"
+                      @click="addEditModal.scenEditMode='parameters'"
+                      data-tooltip="Edit parameter dynamics">
+                Parameters
+              </button>            
+            </div>
           </div>
+          
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" :disabled="addEditModal.scenSummary.progsetname=='None'"
-            @click="addEditModal.scenEditMode='progbudget'" data-tooltip="Edit programs budget">Programs budget</button>
+            <div v-if="addEditModal.scenEditMode == 'progbudget'">
+              <button class="btn __blue"
+                      :disabled="addEditModal.scenSummary.progsetname=='None'"
+                      @click="addEditModal.scenEditMode='progbudget'"
+                      data-tooltip="Edit programs budget">
+                Programs budget
+              </button>
+            </div>
+            <div v-else>
+              <button class="btn __bw"
+                      :disabled="addEditModal.scenSummary.progsetname=='None'"
+                      @click="addEditModal.scenEditMode='progbudget'"
+                      data-tooltip="Edit programs budget">
+                Programs budget
+              </button>            
+            </div>
           </div>
+          
           <div style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" :disabled="addEditModal.scenSummary.progsetname=='None'" 
-            @click="addEditModal.scenEditMode='progcoverage'" data-tooltip="Edit programs coverage">Programs coverage</button>
+            <div v-if="addEditModal.scenEditMode == 'progcoverage'">
+              <button class="btn __blue"
+                      :disabled="addEditModal.scenSummary.progsetname=='None'" 
+                      @click="addEditModal.scenEditMode='progcoverage'"
+                      data-tooltip="Edit programs coverage">
+                Programs coverage
+              </button>
+            </div>
+            <div v-else>
+              <button class="btn __bw"
+                      :disabled="addEditModal.scenSummary.progsetname=='None'" 
+                      @click="addEditModal.scenEditMode='progcoverage'"
+                      data-tooltip="Edit programs coverage">
+                Programs coverage
+              </button>            
+            </div>           
           </div>
           <br><br>
           

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2018-09-09
+Last update: 2019-03-01
 -->
 
 <template>
@@ -197,6 +197,10 @@ Last update: 2018-09-09
           <input type="text"
                  class="txbox"
                  v-model="addEditModal.scenSummary.name"/><br>
+                 
+          <!-- TODO: Set these in a row. -->
+          [Set this stuff in a row...]<br>
+          
           <b>Parameter set</b><br>
           <select v-model="parsetOptions[0]">
             <option v-for='parset in parsetOptions'>
@@ -209,32 +213,67 @@ Last update: 2018-09-09
               {{ progset }}
             </option>
           </select><br><br>
-          <b>Budget year</b><br>
+          <b>Program start year</b><br>
           <input type="text"
                  class="txbox"
                  v-model="addEditModal.scenSummary.alloc_year"/><br>
-          <table class="table table-bordered table-hover table-striped" style="width: 100%">
-            <thead>
-            <tr>
-              <th>Program</th>
-              <th>Budget</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr v-for="item in addEditModal.scenSummary.alloc">
-              <td>
-                {{ item[2] }}
-              </td>
-              <td>
-                <input type="text"
-                       class="txbox"
-                       v-model="item[1]"
-                       style="text-align: right"
-                />
-              </td>
-            </tr>
-            </tbody>
-          </table>
+                 
+          [Parameters, Programs budget, Programs coverage buttons...]<br><br>
+          
+          <div v-if="addEditModal.scenEditMode == 'parameters'">
+            Crazy parametric foofah!...<br>
+          </div>
+    
+          <div v-if="addEditModal.scenEditMode == 'progbudget'">
+            <table class="table table-bordered table-hover table-striped" style="width: 100%">
+              <thead>
+              <tr>
+                <th>Program</th>
+                <th>Budget</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr v-for="item in addEditModal.scenSummary.alloc">
+                <td>
+                  {{ item[2] }}
+                </td>
+                <td>
+                  <input type="text"
+                         class="txbox"
+                         v-model="item[1]"
+                         style="text-align: right"
+                  />
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          
+          <div v-if="addEditModal.scenEditMode == 'progcoverage'">
+            <table class="table table-bordered table-hover table-striped" style="width: 100%">
+              <thead>
+              <tr>
+                <th>Program</th>
+                <th>Coverage</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr v-for="item in addEditModal.scenSummary.alloc">
+                <td>
+                  {{ item[2] }}
+                </td>
+                <td>
+                  <input type="text"
+                         class="txbox"
+                         v-model="item[1]"
+                         style="text-align: right"
+                  />
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          
         </div>
         <div style="text-align:justify">
           <button @click="addBudgetScen()" class='btn __green' style="display:inline-block">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -226,61 +226,56 @@ Last update: 2019-03-21
           </div><br>
           
           <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenEditMode == 'progbudget'">
+            <div v-if="addEditModal.scenSummary.scentype == 'budget'">
               <button class="btn __blue"
                       :disabled="addEditModal.scenSummary.progsetname=='None'"
-                      @click="addEditModal.scenEditMode='progbudget'"
-                      data-tooltip="Edit programs budget">
+                      @click="addEditModal.scenSummary.scentype='budget'">
                 Budget scenario
               </button>
             </div>
             <div v-else>
               <button class="btn __bw"
                       :disabled="addEditModal.scenSummary.progsetname=='None'"
-                      @click="addEditModal.scenEditMode='progbudget'"
-                      data-tooltip="Edit programs budget">
+                      @click="addEditModal.scenSummary.scentype='budget'">
                 Budget scenario
               </button>            
             </div>
           </div>
           
           <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenEditMode == 'progcoverage'">
+            <div v-if="addEditModal.scenSummary.scentype == 'coverage'">
               <button class="btn __blue"
                       :disabled="addEditModal.scenSummary.progsetname=='None'" 
-                      @click="addEditModal.scenEditMode='progcoverage'"
-                      data-tooltip="Edit programs coverage">
+                      @click="addEditModal.scenSummary.scentype='coverage'">
                 Coverage scenario
               </button>
             </div>
             <div v-else>
               <button class="btn __bw"
                       :disabled="addEditModal.scenSummary.progsetname=='None'" 
-                      @click="addEditModal.scenEditMode='progcoverage'"
-                      data-tooltip="Edit programs coverage">
+                      @click="addEditModal.scenSummary.scentype='coverage'">
                 Coverage scenario
               </button>            
             </div>           
           </div>
          
           <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenEditMode == 'parameters'">
+            <div v-if="addEditModal.scenSummary.scentype == 'parameter'">
               <button class="btn __blue"
-                      @click="addEditModal.scenEditMode='parameters'"
-                      data-tooltip="Edit parameter dynamics">
+                      @click="addEditModal.scenSummary.scentype='parameter'">
                 Parameter scenario
               </button>
             </div>
             <div v-else>
               <button class="btn __bw"
-                      @click="addEditModal.scenEditMode='parameters'"
-                      data-tooltip="Edit parameter dynamics">
+                      @click="addEditModal.scenSummary.scentype='parameter'">
                 Parameter scenario
               </button>            
             </div>
           </div>
-          <br><br>         
-          <div v-if="addEditModal.scenEditMode == 'progbudget'">
+          <br><br> 
+          
+          <div v-if="addEditModal.scenSummary.scentype == 'budget'">
             <div class="scrolltable" style="max-height: 80vh;">
               <table class="table table-bordered table-hover table-striped" style="width: 100%">
                 <thead>
@@ -312,7 +307,7 @@ Last update: 2019-03-21
                 </tr>
                 </thead>
                 <tbody>
-                <tr v-for="prog in addEditModal.scenSummary.progvals">
+                <tr v-for="prog in addEditModal.scenSummary.progs">
                   <td>
                     {{ prog.name }}
                   </td>
@@ -330,7 +325,7 @@ Last update: 2019-03-21
             </div>
           </div>
           
-          <div v-if="addEditModal.scenEditMode == 'progcoverage'">
+          <div v-if="addEditModal.scenSummary.scentype == 'coverage'">
             <div class="scrolltable" style="max-height: 80vh;">
               <table class="table table-bordered table-hover table-striped" style="width: 100%">
                 <thead>
@@ -341,11 +336,28 @@ Last update: 2019-03-21
                 </tr>                
                 <tr>
                   <th>Program</th>
-                  <th v-for="year in addEditModal.scenSummary.coverageyears">{{ year }}</th>
+                  <th v-for="(val, index) in addEditModal.scenSummary.coverageyears">
+                    <select v-model="addEditModal.scenSummary.coverageyears[index]">
+                      <option v-for='year in validSimYears'>
+                        {{ year }}
+                      </option>
+                    </select> 
+                    <button @click="modalRemoveCoverageYear(index)" class='btn __red' style="display:inline-block">
+                      X
+                    </button>         
+                  </th>                  
+                  <th>
+                    <button @click="modalAddCoverageYear()" class='btn __green' style="display:inline-block">
+                      +
+                    </button>
+                    <button @click="resetToProgbook()" class='btn __red' style="display:inline-block">
+                      Reset to progbook
+                    </button>                                        
+                  </th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr v-for="prog in addEditModal.scenSummary.progvals">
+                <tr v-for="prog in addEditModal.scenSummary.progs">
                   <td>
                     {{ prog.name }}
                   </td>
@@ -361,7 +373,7 @@ Last update: 2019-03-21
             </div>
           </div>
           
-          <div v-if="addEditModal.scenEditMode == 'parameters'">
+          <div v-if="addEditModal.scenSummary.scentype == 'parameter'">
             Complicated parameters GUI logic...<br><br>
           </div>
              

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -258,12 +258,7 @@ Last update: 2019-03-16
                       <option v-for='year in validSimYears'>
                         {{ year }}
                       </option>
-                    </select>                 
-<!--                    <input type="text"
-                           class="txbox"
-                           style="text-align: right"
-                           v-model="addEditModal.scenSummary.budgetyears[index]"/> --> 
-<!--                    {{ addEditModal.scenSummary.budgetyears[index] }}    -->   
+                    </select> 
                     <button @click="modalRemoveBudgetYear(index)" class='btn __red' style="display:inline-block">
                       X
                     </button>         

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -281,20 +281,19 @@ Last update: 2019-03-06
                 </tr>                
                 <tr>
                   <th>Program</th>
-                  <th>Coverage</th>
+                  <th v-for="year in addEditModal.scenSummary.coverageyears">{{ year }}</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr v-for="item in addEditModal.scenSummary.alloc">
+                <tr v-for="prog in addEditModal.scenSummary.progvals">
                   <td>
-                    {{ item[2] }}
+                    {{ prog.name }}
                   </td>
-                  <td>
+                  <td v-for="(val, index) in prog.coveragevals">
                     <input type="text"
                            class="txbox"
-                           v-model="item[1]"
                            style="text-align: right"
-                    />
+                           v-model="prog.coveragevals[index]"/>
                   </td>
                 </tr>
                 </tbody>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -391,7 +391,11 @@ Last update: 2019-04-06
                     {{ paramoverwrite.groupname }}
                   </td>
                   <td>
-                    {{ paramoverwrite.paramcodename }}
+                    <select v-model="paramoverwrite.popname">
+                      <option v-for="popname in paramGroups.popnames">
+                        {{ popname }}
+                      </option>
+                    </select>
                   </td>                  
                   <td v-for="(val, index) in paramoverwrite.paramvals">
                     <input type="text"

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -373,7 +373,8 @@ Last update: 2019-04-10
                 </tr>
                 </thead>
                 <tbody>
-                <tr v-for="paramoverwrite in addEditModal.scenSummary.paramoverwrites">
+<!--                <tr v-for="paramoverwrite in addEditModal.scenSummary.paramoverwrites"> -->
+                <tr v-for="paramoverwrite in sortedParamOverwrites">
                   <td>
                     <select v-model="paramoverwrite.paramname">
                       <option v-for="paramname in paramGroupMembers(paramoverwrite.groupname)">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-16
+Last update: 2019-03-21
 -->
 
 <template>
@@ -226,29 +226,12 @@ Last update: 2019-03-16
           </div><br>
           
           <div style="display:inline-block; padding-right:10px">
-            <div v-if="addEditModal.scenEditMode == 'parameters'">
-              <button class="btn __blue"
-                      @click="addEditModal.scenEditMode='parameters'"
-                      data-tooltip="Edit parameter dynamics">
-                Parameters
-              </button>
-            </div>
-            <div v-else>
-              <button class="btn __bw"
-                      @click="addEditModal.scenEditMode='parameters'"
-                      data-tooltip="Edit parameter dynamics">
-                Parameters
-              </button>            
-            </div>
-          </div>
-          
-          <div style="display:inline-block; padding-right:10px">
             <div v-if="addEditModal.scenEditMode == 'progbudget'">
               <button class="btn __blue"
                       :disabled="addEditModal.scenSummary.progsetname=='None'"
                       @click="addEditModal.scenEditMode='progbudget'"
                       data-tooltip="Edit programs budget">
-                Programs budget
+                Budget scenario
               </button>
             </div>
             <div v-else>
@@ -256,7 +239,7 @@ Last update: 2019-03-16
                       :disabled="addEditModal.scenSummary.progsetname=='None'"
                       @click="addEditModal.scenEditMode='progbudget'"
                       data-tooltip="Edit programs budget">
-                Programs budget
+                Budget scenario
               </button>            
             </div>
           </div>
@@ -267,7 +250,7 @@ Last update: 2019-03-16
                       :disabled="addEditModal.scenSummary.progsetname=='None'" 
                       @click="addEditModal.scenEditMode='progcoverage'"
                       data-tooltip="Edit programs coverage">
-                Programs coverage
+                Coverage scenario
               </button>
             </div>
             <div v-else>
@@ -275,16 +258,28 @@ Last update: 2019-03-16
                       :disabled="addEditModal.scenSummary.progsetname=='None'" 
                       @click="addEditModal.scenEditMode='progcoverage'"
                       data-tooltip="Edit programs coverage">
-                Programs coverage
+                Coverage scenario
               </button>            
             </div>           
           </div>
-          <br><br>
-          
-          <div v-if="addEditModal.scenEditMode == 'parameters'">
-            Complicated parameters GUI logic...<br><br>
+         
+          <div style="display:inline-block; padding-right:10px">
+            <div v-if="addEditModal.scenEditMode == 'parameters'">
+              <button class="btn __blue"
+                      @click="addEditModal.scenEditMode='parameters'"
+                      data-tooltip="Edit parameter dynamics">
+                Parameter scenario
+              </button>
+            </div>
+            <div v-else>
+              <button class="btn __bw"
+                      @click="addEditModal.scenEditMode='parameters'"
+                      data-tooltip="Edit parameter dynamics">
+                Parameter scenario
+              </button>            
+            </div>
           </div>
-    
+          <br><br>         
           <div v-if="addEditModal.scenEditMode == 'progbudget'">
             <div class="scrolltable" style="max-height: 80vh;">
               <table class="table table-bordered table-hover table-striped" style="width: 100%">
@@ -366,6 +361,10 @@ Last update: 2019-03-16
             </div>
           </div>
           
+          <div v-if="addEditModal.scenEditMode == 'parameters'">
+            Complicated parameters GUI logic...<br><br>
+          </div>
+             
         </div>
         <div style="text-align:justify">
           <button @click="modalSave()" class='btn __green' style="display:inline-block">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -72,7 +72,7 @@ Last update: 2019-03-16
             <div>
 
               <b>Year: &nbsp;</b>
-              <select v-model="endYear" @change="reloadGraphs(true)">
+              <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in projectionYears'>
                   {{ year }}
                 </option>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-03-15
+Last update: 2019-03-16
 -->
 
 <template>
@@ -254,10 +254,11 @@ Last update: 2019-03-15
                 <tr>
                   <th>Program</th>
                   <th v-for="(val, index) in addEditModal.scenSummary.budgetyears">
-                    <input type="text"
+<!--                    <input type="text"
                            class="txbox"
                            style="text-align: right"
-                           v-model="addEditModal.scenSummary.budgetyears[index]"/>   
+                           v-model="addEditModal.scenSummary.budgetyears[index]"/> --> 
+                    {{ addEditModal.scenSummary.budgetyears[index] }}       
                     <button @click="modalRemoveBudgetYear(index)" class='btn __red' style="display:inline-block">
                       X
                     </button>         

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -255,12 +255,12 @@ Last update: 2019-03-12
                            class="txbox"
                            style="text-align: right"
                            v-model="addEditModal.scenSummary.budgetyears[index]"/>   
-                    <button @click="modalSave()" class='btn __red' style="display:inline-block">
+                    <button @click="modalRemoveBudgetYear(index)" class='btn __red' style="display:inline-block">
                       X
                     </button>         
                   </th>                  
                   <th>
-                    <button @click="modalSave()" class='btn __green' style="display:inline-block">
+                    <button @click="modalAddBudgetYear()" class='btn __green' style="display:inline-block">
                       +
                     </button>
                   </th>


### PR DESCRIPTION
This PR--which presently also requires the use of the `combined-scenarios` branch of the `atomica` repo--reworks the Scenario page of the web application to broaden the types of scenarios that the user can generate.  The present `develop` version of the TB GUI only has budget scenarios and for these, spending allocations can only be set for a single year.  In this branch, we implement:
* budget scenarios where program spending can be allocated for multiple years (with simulation spending interpolating between the set values)
* coverage scenarios where program coverages (in % of the target population) can be set for multiple years
* parameter scenarios where parameters can be modified in multiple years during scenarios that run without programs.