### PR TITLE
Minor scenario page fixes

### DIFF
--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1693,7 +1693,6 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
     # when the dropdown is
 
     budget_format_number = lambda x: format(int(round(float(x))), ',') if x is not None else None
-    # coverage_format_number = lambda x: float(x) if x is not None else None
     coverage_format_number = lambda x: round(float(x), 2) if x is not None else None
 
     if scen.progsetname:

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1825,12 +1825,14 @@ def get_initial_coverages(project_id, js_scen, verbose=True):
     # Run the scenario.
     result = py_scen.run(project=proj, store_results=False)
 
-    covs = result.get_coverage(quantity='fraction', year=py_scen.start_year)
+    # Get all of the coverages at the program start year.
+    raw_covs = result.get_coverage(quantity='fraction', year=py_scen.start_year)
 
-    # For each of the elements in the arrays passed in, pull out interpolation values.
-    # covs = []
-    # for ind, param_code in enumerate(param_code_names):
-    #     covs.append(parset.pars[param_code].interpolate(interp_year, pop_names[ind])[0])
+    # Get the coverages in the order that the programs are in the JSON representation of the scenario, and convert to
+    # percentages.
+    covs = []
+    for js_prog in js_scen['progs']:
+        covs.append(raw_covs[js_prog['shortname']][0] * 100.0)
 
     if verbose:
         print('JavaScript initial program coverages:')

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1369,20 +1369,20 @@ def make_plots(proj, results, tool=None, year=None, pops=None, cascade=None, plo
         output['graphs'] += d['graphs']
         output['legends'] += d['legends']
 
-    if plot_budget:
-        # Make program related plots
-        d, figs, legends = get_budget_plots(results=results,year=year)
-        append_plots(d, figs, legends)
-
-        d, figs, legends = get_coverage_plot(results=results)
-        append_plots(d, figs, legends)
-
     cascadeoutput, cascadefigs, cascadelegends = get_cascade_plot(proj, results, year=year, pops=pops, cascade=cascade, plot_budget=plot_budget)
     append_plots(cascadeoutput,cascadefigs,cascadelegends)
 
     if tool != 'cascade':
         if calibration: d, figs, legends = get_atomica_plots(proj, results=results, pops=pops, plot_options=plot_options, stacked=False, calibration=True)
         else:           d, figs, legends = get_atomica_plots(proj, results=results, pops=pops, plot_options=plot_options)
+        append_plots(d, figs, legends)
+
+    if plot_budget:
+        # Make program related plots
+        d, figs, legends = get_budget_plots(results=results,year=year)
+        append_plots(d, figs, legends)
+
+        d, figs, legends = get_coverage_plot(results=results)
         append_plots(d, figs, legends)
 
     savefigs(all_figs, username=proj.webapp.username) # WARNING, dosave ignored fornow

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1856,6 +1856,17 @@ def param_code_name_to_param_group_name(code_name, proj):
 
 
 @RPC()
+def get_param_interpolations(project_id, verbose=True):
+    print('Getting parameter interpolation values...')
+    proj = load_project(project_id, die=True)
+    return 5432.1
+    # if verbose:
+    #     print('JavaScript parameter interpolations:')
+    #     sc.pp(scenario_jsons)
+    # return scenario_jsons
+
+
+@RPC()
 def get_scen_info(project_id, verbose=True):
     print('Getting scenario info...')
     proj = load_project(project_id, die=True)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1856,10 +1856,14 @@ def param_code_name_to_param_group_name(code_name, proj):
 
 
 @RPC()
-def get_param_interpolations(project_id, verbose=True):
+def get_param_interpolations(project_id, progset_name, param_code_names, pop_names, interp_year, verbose=True):
     print('Getting parameter interpolation values...')
     proj = load_project(project_id, die=True)
-    return 5432.1
+
+    progset = proj.progsets[progset_name]
+
+    num_interps = len(param_code_names)
+    return [5432.1] * num_interps
     # if verbose:
     #     print('JavaScript parameter interpolations:')
     #     sc.pp(scenario_jsons)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1856,18 +1856,21 @@ def param_code_name_to_param_group_name(code_name, proj):
 
 
 @RPC()
-def get_param_interpolations(project_id, progset_name, param_code_names, pop_names, interp_year, verbose=True):
+def get_param_interpolations(project_id, parset_name, param_code_names, pop_names, interp_year, verbose=True):
     print('Getting parameter interpolation values...')
     proj = load_project(project_id, die=True)
 
-    progset = proj.progsets[progset_name]
+    parset = proj.parsets[parset_name]
 
-    num_interps = len(param_code_names)
-    return [5432.1] * num_interps
-    # if verbose:
-    #     print('JavaScript parameter interpolations:')
-    #     sc.pp(scenario_jsons)
-    # return scenario_jsons
+    # For each of the elements in the arrays passed in, pull out interpolation values.
+    interps = []
+    for ind, param_code in enumerate(param_code_names):
+        interps.append(parset.pars[param_code].interpolate(interp_year, pop_names[ind])[0])
+
+    if verbose:
+        print('JavaScript parameter interpolations:')
+        sc.pp(interps)
+    return interps
 
 
 @RPC()

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1692,7 +1692,9 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
     # entirely here if the progsetname is 'None' and would instead be called in the callback
     # when the dropdown is
 
-    format_number = lambda x: format(int(round(float(x))), ',') if x is not None else None
+    budget_format_number = lambda x: format(int(round(float(x))), ',') if x is not None else None
+    # coverage_format_number = lambda x: float(x) if x is not None else None
+    coverage_format_number = lambda x: round(float(x), 2) if x is not None else None
 
     if scen.progsetname:
         progset = proj.progsets[scen.progsetname]
@@ -1708,7 +1710,7 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
                 progdict['budgetvals'] = []
                 for year in js_scen['budgetyears']:
                     val = scen.alloc[prog.name].get(year)
-                    progdict['budgetvals'].append(format_number(val))
+                    progdict['budgetvals'].append(budget_format_number(val))
             else:
                 progdict['budgetvals'] = [None] * len(js_scen['budgetyears'])
         elif js_scen['scentype'] == 'coverage':
@@ -1718,7 +1720,7 @@ def py_to_js_scen(scen: at.Scenario, proj=at.Project) -> dict:
                     val = scen.coverage[prog.name].get(year)
                     if val is not None:
                         val *= 100
-                    progdict['coveragevals'].append(format_number(val))
+                    progdict['coveragevals'].append(coverage_format_number(val))
             else:
                 progdict['coveragevals'] = [None] * len(js_scen['coverageyears'])
 
@@ -1829,10 +1831,10 @@ def get_initial_coverages(project_id, js_scen, verbose=True):
     raw_covs = result.get_coverage(quantity='fraction', year=py_scen.start_year)
 
     # Get the coverages in the order that the programs are in the JSON representation of the scenario, and convert to
-    # percentages.
+    # percentages and round to 2 significant figures.
     covs = []
     for js_prog in js_scen['progs']:
-        covs.append(raw_covs[js_prog['shortname']][0] * 100.0)
+        covs.append(round(raw_covs[js_prog['shortname']][0] * 100.0, 2))
 
     if verbose:
         print('JavaScript initial program coverages:')

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1817,6 +1817,28 @@ def get_baseline_spending(project_id, verbose=True):
 
 
 @RPC()
+def get_initial_coverages(project_id, js_scen, verbose=True):
+    print('Getting initial program coverage values...')
+    py_scen = js_to_py_scen(js_scen)
+    proj = load_project(project_id, die=True)
+
+    # Run the scenario.
+    result = py_scen.run(project=proj, store_results=False)
+
+    covs = result.get_coverage(quantity='fraction', year=py_scen.start_year)
+
+    # For each of the elements in the arrays passed in, pull out interpolation values.
+    # covs = []
+    # for ind, param_code in enumerate(param_code_names):
+    #     covs.append(parset.pars[param_code].interpolate(interp_year, pop_names[ind])[0])
+
+    if verbose:
+        print('JavaScript initial program coverages:')
+        sc.pp(covs)
+    return covs
+
+
+@RPC()
 def get_param_groups(project_id, verbose=True):
     print('Getting parameter groups...')
     proj = load_project(project_id, die=True)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1755,7 +1755,7 @@ def js_to_py_scen(js_scen: dict) -> at.Scenario:
                 budgetyears = [to_float(x) if sc.isstring(x) else x for x in js_scen['budgetyears']]
                 alloc[prog['shortname']] = at.TimeSeries(budgetyears,[to_float(x) if x is not None else None for x in prog['budgetvals'] ])
         elif scentype == 'coverage':
-            if any(prog['coveragevals']):
+            if any([val is not None for val in prog['coveragevals']]):
                 coverageyears = [to_float(x) if sc.isstring(x) else x for x in js_scen['coverageyears']]
                 coverage[prog['shortname']] = at.TimeSeries(coverageyears,[to_float(x)/100.0 if x is not None else None for x in prog['coveragevals']])
 

--- a/atomica_apps/version.py
+++ b/atomica_apps/version.py
@@ -6,7 +6,7 @@ Standard location for module version number and date.
 
 import sciris as sc
 
-__version__ = "2.0.0"
-__versiondate__ = "2019-04-12"
+__version__ = "2.0.1"
+__versiondate__ = "2019-05-03"
 __gitinfo__ = sc.gitinfo(__file__, verbose=False)
 

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -406,21 +406,39 @@ var ScenarioMixin = {
     modalAddParameters(selectedParamGroup, selectedParams, selectedPopulations) {
       console.log('modalAddParameter() called')
       
-      let paramname = this.paramGroupMembers(selectedParamGroup)[0]
+      var paramname
+      var popname
+      var newParamOverwrite
+      
+      // Create an array of nulls to be used to set the initial parameter values.
       let newParamvals = []
       if (this.addEditModal.scenSummary.paramoverwrites.length > 0) {
         for (var i = 0; i < this.addEditModal.scenSummary.paramoverwrites[0].paramvals.length; i++) {
           newParamvals.push(null)
         }
-      }      
-      let newParamOverwrite = {
-        paramname: paramname,
-        paramcodename: this.getParamCodeNameFromDisplayName(paramname), 
-        groupname: selectedParamGroup, 
-        popname: this.paramGroups.popnames[0], 
-        paramvals: newParamvals,
       }
-      this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
+      
+      // Loop over the selected parameters...
+      for (var i = 0; i < selectedParams.length; i++) {
+        paramname = selectedParams[i]
+        
+        // Loop over the selected populations...
+        for (var j = 0; j < selectedPopulations.length; j++) {
+          popname = selectedPopulations[j]
+          
+          // Create the overwrite row.
+          newParamOverwrite = {
+            paramname: paramname,
+            paramcodename: this.getParamCodeNameFromDisplayName(paramname), 
+            groupname: selectedParamGroup, 
+            popname: popname, 
+            paramvals: _.cloneDeep(newParamvals) 
+          }
+          
+          // Push the new overwrite to the table.
+          this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
+        }
+      }
     },
     
     modalDeleteParameter(paramoverwrite) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -455,14 +455,42 @@ var ScenarioMixin = {
         paramInterpolations.push(1234.5)
       }
       
+      // Do the RPC call.
+      this.$sciris.start(this)
+      this.$sciris.rpc('get_param_interpolations', [this.projectID])
+        .then(response => {
+          let crazyVal = response.data
+          
+          console.log('crazyVal: ', crazyVal)
+            
+          // For each of the rows we just added, add the interpolated parameter value for the 
+          // first year column.
+          for (var i = this.addEditModal.scenSummary.paramoverwrites.length - 
+            selectedParams.length * selectedPopulations.length; 
+            i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+/*            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
+              paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length] */
+            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = crazyVal           
+          }
+
+          // Hack to get the Vue display of paramoverwrites to update
+          this.addEditModal.scenSummary.paramoverwrites.push(this.addEditModal.scenSummary.paramoverwrites[0])
+          this.addEditModal.scenSummary.paramoverwrites.pop()
+          
+          this.$sciris.succeed(this, '')
+        })
+        .catch(error => {
+          this.$sciris.fail(this, 'Could not get parameter interpolations', error)
+        })
+        
       // For each of the rows we just added, add the interpolated parameter value for the 
       // first year column.
-      for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
+/*      for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
         selectedPopulations.length; 
         i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
         this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
           paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length]
-      }
+      } */
     },
     
     modalDeleteParameter(paramoverwrite) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -186,7 +186,7 @@ var ScenarioMixin = {
         .then(response => {
           this.paramGroups = response.data // Set the parameter groups to what we received.
           this.addEditModal.selectedParamGroup = this.paramGroups.grouplist[0]
-          this.$sciris.succeed(this, 'Parameter groups loaded')
+          this.$sciris.succeed(this, '')
         })
         .catch(error => {
           this.$sciris.fail(this, 'Could not get parameter groups', error)

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -439,6 +439,19 @@ var ScenarioMixin = {
           this.addEditModal.scenSummary.paramoverwrites.push(newParamOverwrite)
         }
       }
+      
+      // If we have no year columns yet, add one.
+      if (this.addEditModal.scenSummary.paramoverwrites[0].paramvals.length == 0) {
+        this.modalAddParamYear()
+      }
+      
+      // For each of the rows we just added, add the interpolated parameter value for the 
+      // first year column.
+      for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
+        selectedPopulations.length; 
+        i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+        this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 1234.5
+      }
     },
     
     modalDeleteParameter(paramoverwrite) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -40,7 +40,9 @@ var ScenarioMixin = {
         scenSummary: {},
         origName: '',
         mode: 'add',  
-        selectedParamGroup: '',        
+        selectedParamGroup: '',   
+        selectedParams: [],
+        selectedPopulations: [],        
       },
     }
   },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -409,6 +409,7 @@ var ScenarioMixin = {
       var paramname
       var popname
       var newParamOverwrite
+      var paramInterpolations
       
       // Create an array of nulls to be used to set the initial parameter values.
       let newParamvals = []
@@ -445,12 +446,22 @@ var ScenarioMixin = {
         this.modalAddParamYear()
       }
       
+      // Build arguments for an RPC call to get all of the interpolated parameter values 
+      // for the first year column.
+      paramInterpolations = []
+      for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
+        selectedPopulations.length; 
+        i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+        paramInterpolations.push(1234.5)
+      }
+      
       // For each of the rows we just added, add the interpolated parameter value for the 
       // first year column.
       for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
         selectedPopulations.length; 
         i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
-        this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 1234.5
+        this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
+          paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length]
       }
     },
     

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -403,7 +403,7 @@ var ScenarioMixin = {
       }
     },
     
-    modalAddParameter(selectedParamGroup) {
+    modalAddParameters(selectedParamGroup, selectedParams, selectedPopulations) {
       console.log('modalAddParameter() called')
       
       let paramname = this.paramGroupMembers(selectedParamGroup)[0]

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -346,16 +346,44 @@ var ScenarioMixin = {
       // year already there plus 1.
       if (this.addEditModal.scenSummary.coverageyears.length > 0) {
         newYear = Math.max(...this.addEditModal.scenSummary.coverageyears) + 1
-      // Otherwise, make the new year the data_end year.
+      // Otherwise, make the new year the program start year.
       } else {
-        newYear = this.spendingBaselines.data_end
+        newYear = this.addEditModal.scenSummary.progstartyear
       }
       this.addEditModal.scenSummary.coverageyears.push(newYear)
       
       // For each program, add a null to the end of the list, so we have a blank textbox.
       for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
         this.addEditModal.scenSummary.progs[i].coveragevals.push(null)
-      }      
+      }
+
+      // If we now have just one year column...
+      if (this.addEditModal.scenSummary.coverageyears.length == 1) {
+        // Run the RPC to to pull out the coverages at the program start year.
+        this.$sciris.start(this)
+        this.$sciris.rpc('get_initial_coverages', [this.projectID, this.addEditModal.scenSummary])
+        .then(response => {
+/*          paramInterpolations = response.data
+            
+          // For each of the rows we just added, add the interpolated parameter value for the 
+          // first year column.
+          for (var i = this.addEditModal.scenSummary.paramoverwrites.length - 
+            selectedParams.length * selectedPopulations.length; 
+            i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
+              paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length]        
+          }
+
+          // Hack to get the Vue display of paramoverwrites to update
+          this.addEditModal.scenSummary.paramoverwrites.push(this.addEditModal.scenSummary.paramoverwrites[0])
+          this.addEditModal.scenSummary.paramoverwrites.pop() */
+          
+          this.$sciris.succeed(this, '')
+        })
+        .catch(error => {
+          this.$sciris.fail(this, 'Could not get initial coverages', error)
+        })
+      }
     },
     
     modalRemoveCoverageYear(yearindex) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -342,6 +342,8 @@ var ScenarioMixin = {
       console.log('modalAddCoverageYear() called')
     
       var newYear
+      var startingCovs
+      
       // If the coverage years list is non-empty, add a new coverage year which is the maximum 
       // year already there plus 1.
       if (this.addEditModal.scenSummary.coverageyears.length > 0) {
@@ -363,20 +365,16 @@ var ScenarioMixin = {
         this.$sciris.start(this)
         this.$sciris.rpc('get_initial_coverages', [this.projectID, this.addEditModal.scenSummary])
         .then(response => {
-/*          paramInterpolations = response.data
-            
-          // For each of the rows we just added, add the interpolated parameter value for the 
-          // first year column.
-          for (var i = this.addEditModal.scenSummary.paramoverwrites.length - 
-            selectedParams.length * selectedPopulations.length; 
-            i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
-            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
-              paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length]        
+          startingCovs = response.data
+          
+          // For each program, copy the RPC coverages over to the values to be in the textboxes.
+          for (var i = 0; i < this.addEditModal.scenSummary.progs.length; i++) {
+            this.addEditModal.scenSummary.progs[i].coveragevals[0] = startingCovs[i]
           }
-
-          // Hack to get the Vue display of paramoverwrites to update
-          this.addEditModal.scenSummary.paramoverwrites.push(this.addEditModal.scenSummary.paramoverwrites[0])
-          this.addEditModal.scenSummary.paramoverwrites.pop() */
+          
+          // Hack to get the Vue display of progs[x].coveragevals to update
+          this.addEditModal.scenSummary.progs.push(this.addEditModal.scenSummary.progs[0])
+          this.addEditModal.scenSummary.progs.pop()
           
           this.$sciris.succeed(this, '')
         })

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -409,6 +409,8 @@ var ScenarioMixin = {
       var paramname
       var popname
       var newParamOverwrite
+      var paramCodeNames
+      var popNames
       var paramInterpolations
       
       // Create an array of nulls to be used to set the initial parameter values.
@@ -448,29 +450,30 @@ var ScenarioMixin = {
       
       // Build arguments for an RPC call to get all of the interpolated parameter values 
       // for the first year column.
+      paramCodeNames = []
+      popNames = []
       paramInterpolations = []
       for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
         selectedPopulations.length; 
         i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
+        paramCodeNames.push(this.addEditModal.scenSummary.paramoverwrites[i].paramcodename)
+        popNames.push(this.addEditModal.scenSummary.paramoverwrites[i].popname)
         paramInterpolations.push(1234.5)
       }
       
       // Do the RPC call.
       this.$sciris.start(this)
-      this.$sciris.rpc('get_param_interpolations', [this.projectID])
+      this.$sciris.rpc('get_param_interpolations', [this.projectID, this.addEditModal.scenSummary.parsetname, paramCodeNames, popNames, this.addEditModal.scenSummary.paramyears[0]])
         .then(response => {
-          let crazyVal = response.data
-          
-          console.log('crazyVal: ', crazyVal)
+          paramInterpolations = response.data
             
           // For each of the rows we just added, add the interpolated parameter value for the 
           // first year column.
           for (var i = this.addEditModal.scenSummary.paramoverwrites.length - 
             selectedParams.length * selectedPopulations.length; 
             i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
-/*            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
-              paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length] */
-            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = crazyVal           
+            this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
+              paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length]        
           }
 
           // Hack to get the Vue display of paramoverwrites to update
@@ -482,15 +485,6 @@ var ScenarioMixin = {
         .catch(error => {
           this.$sciris.fail(this, 'Could not get parameter interpolations', error)
         })
-        
-      // For each of the rows we just added, add the interpolated parameter value for the 
-      // first year column.
-/*      for (var i = this.addEditModal.scenSummary.paramoverwrites.length - selectedParams.length *   
-        selectedPopulations.length; 
-        i < this.addEditModal.scenSummary.paramoverwrites.length; i++) {
-        this.addEditModal.scenSummary.paramoverwrites[i].paramvals[0] = 
-          paramInterpolations[i - this.addEditModal.scenSummary.paramoverwrites.length + selectedParams.length * selectedPopulations.length]
-      } */
     },
     
     modalDeleteParameter(paramoverwrite) {

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-10
+Last update: 2019-04-12
 -->
 
 <template>
@@ -399,8 +399,8 @@ Last update: 2019-04-10
                            v-model="paramoverwrite.paramvals[index]"/>
                   </td>
                   <td>
-                    <button @click="modalDeleteParameter(paramoverwrite)" class="btn __red">
-                      X
+                    <button @click="modalDeleteParameter(paramoverwrite)" class="btn_small">
+                      <i class="ti-trash"></i>
                     </button>                   
                   </td>
                 </tr>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-04-12
+Last update: 2019-04-16
 -->
 
 <template>
@@ -244,8 +244,28 @@ Last update: 2019-04-12
           
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
+            <b>Parameters</b><br>
+            <select v-model="addEditModal.selectedParams" size="4" multiple>
+              <option v-for="paramname in paramGroupMembers(addEditModal.selectedParamGroup)">
+                {{ paramname }}
+              </option>
+            </select><br><br>
+          </div> 
+
+          <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
+               style="display:inline-block; padding-right:10px">
+            <b>Populations</b><br>
+            <select v-model="addEditModal.selectedPopulations" size="4" multiple>
+              <option v-for="popname in paramGroups.popnames">
+                {{ popname }}
+              </option>
+            </select><br><br>
+          </div> 
+      
+          <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
+               style="display:inline-block; padding-right:10px">
             <button class="btn __blue" @click="modalAddParameter(addEditModal.selectedParamGroup)">
-              Add parameter from group
+              Add parameters...
             </button><br><br>
           </div>
           <br>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -262,9 +262,11 @@ Last update: 2019-04-16
             </select><br><br>
           </div> 
       
-          <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
+          <div v-if="addEditModal.scenSummary.scentype == 'parameter'"     
                style="display:inline-block; padding-right:10px">
-            <button class="btn __blue" @click="modalAddParameter(addEditModal.selectedParamGroup)">
+            <button class="btn __blue"
+                    @click="modalAddParameters(addEditModal.selectedParamGroup, addEditModal.selectedParams, addEditModal.selectedPopulations)"
+                    :disabled="(addEditModal.selectedParams.length == 0) || (addEditModal.selectedPopulations.length == 0)">
               Add parameters...
             </button><br><br>
           </div>


### PR DESCRIPTION
This PR makes some additional changes to the scenarios page of the TB GUI to improve the ease of use.  This includes:
* replacing red X icons with gray trashcan icons
* getting rid of notifications for parameter groups being loaded
* reordering the order that plots are displayed in when scenarios are run
* allowing adding of multiple rows to parameter overwrites table at a time via dropdown menus for parameter and population names
* providing initial values for coverages or parameter settings for coverage or parameter scenarios, respectively