### PR TITLE
Graph improvements

### DIFF
--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -2220,10 +2220,9 @@ def clear_cached_results(proj, project_id, spare_calibration=False, verbose=True
     ''' Clear all cached results from the project '''
     for key,result_key in proj.results.items():
         if sc.isstring(result_key):
-            del_result(result_key, project_id)
-            # result = load_result(result_key)
-            # proj.results[key] = result
-            if verbose: print('Deleted result "%s" from "%s"' % (key, result_key))
+            if (not spare_calibration) or "calibration" not in result_key:
+                del_result(result_key, project_id)
+                if verbose: print('Deleted result "%s" from "%s"' % (key, result_key))
     save_project(proj)
     return proj
 

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -697,7 +697,7 @@ def upload_databook(databook_filename, project_id):
     print(">> upload_databook '%s'" % databook_filename)
     proj = load_project(project_id, die=True)
     proj.load_databook(databook_path=databook_filename)
-    clear_cached_results(proj, project_id)
+    clear_cached_results(proj, project_id, spare_calibration=False)
     save_project(proj) # Save the new project in the DataStore.
     return { 'projectID': str(proj.uid) } # Return the new project UID in the return message.
 
@@ -707,7 +707,8 @@ def upload_progbook(progbook_filename, project_id):
     ''' Upload a program book to a project. '''
     print(">> upload_progbook '%s'" % progbook_filename)
     proj = load_project(project_id, die=True)
-    proj.load_progbook(progbook_path=progbook_filename) 
+    proj.load_progbook(progbook_path=progbook_filename)
+    clear_cached_results(proj, project_id, spare_calibration=True)
     save_project(proj)
     return { 'projectID': str(proj.uid) }
 
@@ -2215,7 +2216,7 @@ def retrieve_results(proj, verbose=True):
     return proj
 
 
-def clear_cached_results(proj, project_id, verbose=True):
+def clear_cached_results(proj, project_id, spare_calibration=False, verbose=True):
     ''' Clear all cached results from the project '''
     for key,result_key in proj.results.items():
         if sc.isstring(result_key):

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -696,7 +696,8 @@ def upload_databook(databook_filename, project_id):
     ''' Upload a databook to a project. '''
     print(">> upload_databook '%s'" % databook_filename)
     proj = load_project(project_id, die=True)
-    proj.load_databook(databook_path=databook_filename) 
+    proj.load_databook(databook_path=databook_filename)
+    clear_cached_results(proj, project_id)
     save_project(proj) # Save the new project in the DataStore.
     return { 'projectID': str(proj.uid) } # Return the new project UID in the return message.
 
@@ -2213,7 +2214,19 @@ def retrieve_results(proj, verbose=True):
             if verbose: print('Retrieved result "%s" from "%s"' % (key, result_key))
     return proj
 
-    
+
+def clear_cached_results(proj, project_id, verbose=True):
+    ''' Clear all cached results from the project '''
+    for key,result_key in proj.results.items():
+        if sc.isstring(result_key):
+            del_result(result_key, project_id)
+            # result = load_result(result_key)
+            # proj.results[key] = result
+            if verbose: print('Deleted result "%s" from "%s"' % (key, result_key))
+    save_project(proj)
+    return proj
+
+
 @RPC() 
 def plot_results(project_id, cache_id, plot_options, tool=None, plotyear=None, pops=None, cascade=None, dosave=True, plotbudget=False, calibration=False):
     print('Plotting cached results...')

--- a/src/cascade/app/CalibrationPage.vue
+++ b/src/cascade/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-21
+Last update: 2019-05-23
 -->
 
 <template>
@@ -133,6 +133,9 @@ Last update: 2019-05-21
               <button class="btn btn-icon" @click="scaleFigs(0.9)" data-tooltip="Zoom out">&ndash;</button>
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
+              <button class="btn" @click="reloadGraphs(true)">Refresh</button>
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true; scaleFigs(0.8)">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false; scaleFigs(1.0)">Hide plot selection</button>               
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(serverDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="$globaltool=='tb'" -->

--- a/src/cascade/app/CalibrationPage.vue
+++ b/src/cascade/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2018-10-05
+Last update: 2019-05-21
 -->
 
 <template>
@@ -146,25 +146,17 @@ Last update: 2018-10-05
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-
-                <div class="other-graphs">
-                  <div v-for="index in placeholders">
-                    <div :id="'figcontainer'+index" class="figcontainer" v-show="showGraphDivs[index]">
-                      <div :id="'fig'+index" class="calib-graph">
-                        <!--mpld3 content goes here-->
-                      </div>
-                      <!--<div style="display:inline-block">-->
-                      <!--<button class="btn __bw btn-icon" @click="maximize(index)" data-tooltip="Show legend"><i class="ti-menu-alt"></i></button>-->
-                      <!--</div>-->
-                    </div>
-                  </div>
+                <div class="outcome-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>               
+                <div class="budget-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-
-                <!-- ### Start: Cascade plot ### -->
-                <div class="featured-graphs">
-                  <div :id="'fig0'">
-                    <!-- mpld3 content goes here, no legend for it -->
-                  </div>
+                <div class="coverage-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>
+                <div class="cascade-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
 
                 <!-- ### Start: cascade table ### -->

--- a/src/cascade/app/OptimizationsPage.vue
+++ b/src/cascade/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-27
+Last update: 2019-05-21
 -->
 
 <template>
@@ -85,7 +85,7 @@ Last update: 2019-05-27
               </template>
 
               <b>Year: &nbsp;</b>
-              <select v-model="endYear" @change="reloadGraphs(displayResultDatastoreId, true)">
+              <select v-model="simEndYear" @change="reloadGraphs(displayResultDatastoreId, true)">
                 <option v-for='year in projectionYears'>
                   {{ year }}
                 </option>
@@ -114,27 +114,19 @@ Last update: 2019-05-27
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-
-                <div class="other-graphs">
-                  <div v-for="index in placeholders">
-                    <div :id="'figcontainer'+index" style="display:flex; justify-content:flex-start; padding:5px; border:1px solid #ddd" v-show="showGraphDivs[index]">
-                      <div :id="'fig'+index" class="calib-graph">
-                        <!--mpld3 content goes here-->
-                      </div>
-                      <!--<div style="display:inline-block">-->
-                      <!--<button class="btn __bw btn-icon" @click="maximize(index)" data-tooltip="Show legend"><i class="ti-menu-alt"></i></button>-->
-                      <!--</div>-->
-                    </div>
-                  </div>
+                <div class="outcome-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>               
+                <div class="budget-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>
+                <div class="coverage-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>
+                <div class="cascade-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
 
-                <!-- ### Start: Cascade plot ### -->
-                <div class="featured-graphs">
-                  <div :id="'fig0'">
-                    <!-- mpld3 content goes here, no legend for it -->
-                  </div>
-                </div>
-                <!-- ### End: Cascade plot ### -->
                 <!-- ### Start: cascade table ### -->
                 <div v-if="table" class="calib-tables">
                   <h4>Cascade stage losses</h4>

--- a/src/cascade/app/OptimizationsPage.vue
+++ b/src/cascade/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-21
+Last update: 2019-05-23
 -->
 
 <template>
@@ -100,6 +100,9 @@ Last update: 2019-05-21
               <button class="btn btn-icon" @click="scaleFigs(0.9)" data-tooltip="Zoom out">&ndash;</button>
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
+              <button class="btn" @click="reloadGraphs(displayResultDatastoreId, true)">Refresh</button>
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true; scaleFigs(0.8)">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false; scaleFigs(1.0)">Hide plot selection</button>              
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(displayResultDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="this.$globaltool=='tb'" -->

--- a/src/cascade/app/OptimizationsPage.vue
+++ b/src/cascade/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2018-09-26
+Last update: 2019-05-27
 -->
 
 <template>
@@ -77,7 +77,7 @@ Last update: 2018-09-26
 
               <template v-if="simCascades.length>1">
                 <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(true)">
+                <select v-model="activeCascade" @change="reloadGraphs(displayResultDatastoreId, true)">
                   <option v-for='cascade in simCascades'>
                     {{ cascade }}
                   </option>

--- a/src/cascade/app/ScenariosPage.vue
+++ b/src/cascade/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2018-09-09
+Last update: 2019-05-21
 -->
 
 <template>
@@ -81,7 +81,7 @@ Last update: 2018-09-09
               </template>
 
               <b>Year: &nbsp;</b>
-              <select v-model="endYear" @change="reloadGraphs(true)">
+              <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in projectionYears'>
                   {{ year }}
                 </option>
@@ -110,28 +110,20 @@ Last update: 2018-09-09
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-
-                <div class="other-graphs">
-                  <div v-for="index in placeholders">
-                    <div :id="'figcontainer'+index" style="display:flex; justify-content:flex-start; padding:5px; border:1px solid #ddd" v-show="showGraphDivs[index]">
-                      <div :id="'fig'+index" class="calib-graph">
-                        <!--mpld3 content goes here-->
-                      </div>
-                      <!--<div style="display:inline-block">-->
-                      <!--<button class="btn __bw btn-icon" @click="maximize(index)" data-tooltip="Show legend"><i class="ti-menu-alt"></i></button>-->
-                      <!--</div>-->
-                    </div>
-                  </div>
+                <div class="outcome-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>               
+                <div class="budget-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-
-                <!-- ### Start: Cascade plot ### -->
-                <div class="featured-graphs">
-                  <div :id="'fig0'">
-                    <!-- mpld3 content goes here, no legend for it -->
-                  </div>
+                <div class="coverage-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-                <!-- ### End: Cascade plot ### -->
-                                <!-- ### Start: cascade table ### -->
+                <div class="cascade-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>         
+                
+                <!-- ### Start: cascade table ### -->
                 <div v-if="table" class="calib-tables">
                   <h4>Cascade stage losses</h4>
                   <table class="table table-striped" style="text-align:right;">

--- a/src/cascade/app/ScenariosPage.vue
+++ b/src/cascade/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-21
+Last update: 2019-05-23
 -->
 
 <template>
@@ -96,6 +96,9 @@ Last update: 2019-05-21
               <button class="btn btn-icon" @click="scaleFigs(0.9)" data-tooltip="Zoom out">&ndash;</button>
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
+              <button class="btn" @click="reloadGraphs(true)">Refresh</button>
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true; scaleFigs(0.8)">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false; scaleFigs(1.0)">Hide plot selection</button>               
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(serverDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="$globaltool=='tb'" -->

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -327,7 +327,7 @@ var CalibrationMixin = {
         }) // Go to the server to get the results from the package set.
         .then(response => {
           this.table = response.data.table
-          this.makeGraphs(response.data.graphs)
+          this.makeGraphs(response.data)
           this.$sciris.succeed(this, 'Simulation run, graphs now rendering...')
         })
         .catch(error => {

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -49,7 +49,6 @@ var CalibrationMixin = {
       simYears()     { return utils.simYears(this) },
       simCascades()  { return utils.simCascades(this) },
       activePops()   { return utils.activePops(this) },
-      placeholders() { return this.$sciris.placeholders(this, 1) },
 
       filteredParlist() {
         return this.applyParametersFilter(this.parlist)

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -112,9 +112,12 @@ var CalibrationMixin = {
       getPlotOptions(project_id) { 
         return utils.getPlotOptions(this, project_id) 
       },
-      makeGraphs(graphdata) { 
+/*      makeGraphs(graphdata) { 
         return this.$sciris.makeGraphs(this, graphdata, '/calibration') 
-      },
+      }, */
+      makeGraphs(graphdata) { 
+        return utils.makeGraphs(this, graphdata, '/calibration') 
+      },       
       reloadGraphs(showErr) { 
         // Set to calibration=true
         utils.validateYears(this)  // Make sure the start end years are in the right range.

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -120,6 +120,10 @@ var CalibrationMixin = {
       reloadGraphs(showErr) { 
         // Set to calibration=true
         utils.validateYears(this)  // Make sure the start end years are in the right range.
+        if (this.showPlotControls) {
+          this.scaleFigs(1.0)
+          this.showPlotControls = false
+        }        
         return utils.reloadGraphs(
           this, 
           this.projectID, 

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -51,7 +51,6 @@ var OptimizationMixin = {
     simCascades()  { return utils.simCascades(this) },
     projectionYears()     { return utils.projectionYears(this) },
     activePops()   { return utils.activePops(this) },
-    placeholders() { return this.$sciris.placeholders(this, 1) },
   },
 
   created() {

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -88,6 +88,10 @@ var OptimizationMixin = {
     makeGraphs(graphdata)             { return utils.makeGraphs(this, graphdata, '/optimizations') },reloadGraphs(cache_id, showErr)   { 
       // Make sure the start end years are in the right range.
       utils.validateYears(this);
+      if (this.showPlotControls) {
+        this.scaleFigs(1.0)
+        this.showPlotControls = false
+      }      
       // Set to calibration=false, plotbudget=True
       return utils.reloadGraphs(this, this.projectID, cache_id, showErr, false, true); 
     }, 

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -85,8 +85,8 @@ var OptimizationMixin = {
     clearGraphs()                     { return this.$sciris.clearGraphs(this) },
     togglePlotControls()              { return utils.togglePlotControls(this) },
     getPlotOptions(project_id)        { return utils.getPlotOptions(this, project_id) },
-    makeGraphs(graphdata)             { return this.$sciris.makeGraphs(this, graphdata, '/optimizations') },
-    reloadGraphs(cache_id, showErr)   { 
+/*    makeGraphs(graphdata)             { return this.$sciris.makeGraphs(this, graphdata, '/optimizations') }, */
+    makeGraphs(graphdata)             { return utils.makeGraphs(this, graphdata, '/optimizations') },reloadGraphs(cache_id, showErr)   { 
       // Make sure the start end years are in the right range.
       utils.validateYears(this);
       // Set to calibration=false, plotbudget=True

--- a/src/common/mixins/project.js
+++ b/src/common/mixins/project.js
@@ -21,6 +21,7 @@ var ProjectMixin = {
       defaultPrograms: [],
       progStartYear: [],
       progEndYear: [],
+      simplertModalUid: '',
     }
   },
 
@@ -453,8 +454,21 @@ var ProjectMixin = {
           this.$sciris.fail(this, 'Could not create program book', error)
         })
     },
-
-    uploadDatabook(uid) {
+    
+    uploadDatabookModal(uid) {
+      this.simplertModalUid = uid
+      var obj = { // Alert object data
+        message: 'This will delete any cached results, including for optimizations.  Are you sure you want to proceed?',
+        useConfirmBtn: true,
+        customConfirmBtnClass: 'btn __red',
+        customCloseBtnClass: 'btn',
+        onConfirm: this.uploadDatabook
+      }
+      this.$Simplert.open(obj)
+    },
+    
+    uploadDatabook() {
+      let uid = this.simplertModalUid
       console.log('uploadDatabook() called')
       this.$sciris.upload('upload_databook', [uid], {}, '.xlsx')
         .then(response => {
@@ -467,8 +481,21 @@ var ProjectMixin = {
           this.$sciris.fail(this, 'Could not upload databook', error)
         })
     },
-
-    uploadProgbook(uid) {
+    
+    uploadProgbookModal(uid) {
+      this.simplertModalUid = uid
+      var obj = { // Alert object data
+        message: 'This will delete any cached scenario and optimization results.  Are you sure you want to proceed?',
+        useConfirmBtn: true,
+        customConfirmBtnClass: 'btn __red',
+        customCloseBtnClass: 'btn',
+        onConfirm: this.uploadProgbook
+      }
+      this.$Simplert.open(obj)
+    },
+    
+    uploadProgbook() {
+      let uid = this.simplertModalUid
       // Find the project that matches the UID passed in.
       console.log('uploadProgbook() called')
       this.$sciris.upload('upload_progbook', [uid], {}, '.xlsx')

--- a/src/common/mixins/project.js
+++ b/src/common/mixins/project.js
@@ -458,7 +458,7 @@ var ProjectMixin = {
     uploadDatabookModal(uid) {
       this.simplertModalUid = uid
       var obj = { // Alert object data
-        message: 'This will delete any cached results, including for optimizations.  Are you sure you want to proceed?',
+        message: 'This will clear any results in this project, including the results of any optimizations.  Are you sure you want to proceed?',
         useConfirmBtn: true,
         customConfirmBtnClass: 'btn __red',
         customCloseBtnClass: 'btn',

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -11,7 +11,7 @@ var ScenarioMixin = {
       progsetOptions: [],   
 
       // Plotting data
-      showPlotControls: false,
+      showPlotControls: true,
       hasGraphs: false,
       table: null,
       simStartYear: 0,

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -105,6 +105,10 @@ var ScenarioMixin = {
     makeGraphs(graphdata)             { return utils.makeGraphs(this, graphdata, '/scenarios') },    
     reloadGraphs(showErr)             { 
       utils.validateYears(this);
+      if (this.showPlotControls) {
+        this.scaleFigs(1.0)
+        this.showPlotControls = false
+      }
       // Set to calibration=false, plotbudget=true
       return utils.reloadGraphs(
         this,

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -102,7 +102,8 @@ var ScenarioMixin = {
     clearGraphs()                     { return this.$sciris.clearGraphs(this) },
     togglePlotControls()              { return utils.togglePlotControls(this) },
     getPlotOptions(project_id)        { return utils.getPlotOptions(this, project_id) },
-    makeGraphs(graphdata)             { return this.$sciris.makeGraphs(this, graphdata, '/scenarios') },
+/*    makeGraphs(graphdata)             { return this.$sciris.makeGraphs(this, graphdata, '/scenarios') }, */
+    makeGraphs(graphdata)             { return utils.makeGraphs(this, graphdata, '/scenarios') },    
     reloadGraphs(showErr)             { 
       utils.validateYears(this);
       // Set to calibration=false, plotbudget=true

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -56,7 +56,6 @@ var ScenarioMixin = {
     simCascades()  { return utils.simCascades(this) },
     projectionYears()     { return utils.projectionYears(this) },
     activePops()   { return utils.activePops(this) },
-    placeholders() { return this.$sciris.placeholders(this, 1) },
     sortedParamOverwrites() {
       return this.applyParamOverwriteSorting(this.addEditModal.scenSummary.paramoverwrites)
     },

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -11,7 +11,7 @@ var ScenarioMixin = {
       progsetOptions: [],   
 
       // Plotting data
-      showPlotControls: true,
+      showPlotControls: false,
       hasGraphs: false,
       table: null,
       simStartYear: 0,

--- a/src/common/styles/_graphs.scss
+++ b/src/common/styles/_graphs.scss
@@ -42,16 +42,22 @@
   flex-grow: 1;
   max-height: 80vh;
   overflow-y: auto;
-  .featured-graphs {
-
-  }
-  .other-graphs {
+  .outcome-graphs {
     display: flex;
     flex: 1;
     flex-wrap: wrap;
-    .calib-graph {
-      //flex: 0 0 200px; // CK: Not sure why this was here, but it messes things up
-    }
+  }
+  .budget-graphs {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+  }
+  .coverage-graphs {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+  }
+  .cascade-graphs {
   }
 }
 .figcontainer {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -298,6 +298,92 @@ function reloadGraphs(vm, project_id, cache_id, showNoCacheError, iscalibration,
   })
 }
 
+function makeGraphs(vm, data, routepath) {
+  if (typeof d3 === 'undefined'){
+    console.log("please include d3 to use the makeGraphs function")
+    return false;
+  }
+  if (routepath && routepath !== vm.$route.path) { // Don't render graphs if we've changed page
+    console.log('Not rendering graphs since route changed: ' + routepath + ' vs. ' + vm.$route.path)
+  }
+  else { // Proceed...
+    let waitingtime = 0.5
+    var graphdata = data.graphs
+    // var legenddata = data.legends
+    sciris.status.start(vm) // Start indicating progress.
+    vm.hasGraphs = true
+    sciris.utils.sleep(waitingtime * 1000)
+      .then(response => {
+        let n_plots = graphdata.length
+        // let n_legends = legenddata.length
+        console.log('Rendering ' + n_plots + ' graphs')
+        // if (n_plots !== n_legends) {
+        //   console.log('WARNING: different numbers of plots and legends: ' + n_plots + ' vs. ' + n_legends)
+        // }
+        for (var index = 0; index <= n_plots; index++) {
+          console.log('Rendering plot ' + index)
+          var figlabel    = 'fig' + index
+          var figdiv  = document.getElementById(figlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
+          if (figdiv) {
+            while (figdiv.firstChild) {
+              figdiv.removeChild(figdiv.firstChild);
+            }
+          } else {
+            console.log('WARNING: figdiv not found: ' + figlabel)
+          }
+
+          // Show figure containers
+          if (index>=1 && index<n_plots) {
+            var figcontainerlabel = 'figcontainer' + index
+            var figcontainerdiv = document.getElementById(figcontainerlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
+            if (figcontainerdiv) {
+              figcontainerdiv.style.display = 'flex'
+            } else {
+              console.log('WARNING: figcontainerdiv not found: ' + figcontainerlabel)
+            }
+
+            // var legendlabel = 'legend' + index
+            // var legenddiv  = document.getElementById(legendlabel);
+            // if (legenddiv) {
+            //   while (legenddiv.firstChild) {
+            //     legenddiv.removeChild(legenddiv.firstChild);
+            //   }
+            // } else {
+            //   console.log('WARNING: legenddiv not found: ' + legendlabel)
+            // }
+          }
+
+          // Draw figures
+          try {
+            sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
+              fig.setXTicks(6, function (d) {
+                return d3.format('.0f')(d);
+              });
+              // fig.setYTicks(null, function (d) { // Looks too weird with 500m for 0.5
+              //   return d3.format('.2s')(d);
+              // });
+            }, true);
+          } catch (error) {
+            console.log('Could not plot graph: ' + error.message)
+          }
+
+          // Draw legends
+          // if (index>=1 && index<n_plots) {
+          //   try {
+          //     mpld3.draw_figure(legendlabel, legenddata[index], function (fig, element) {
+          //     });
+          //   } catch (error) {
+          //     console.log(error)
+          //   }
+          //
+          // }
+          vm.showGraphDivs[index] = true;
+        }
+        sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do
+      })
+  }
+}
+
 export default {
   updateSets,
   updateDatasets,
@@ -322,4 +408,6 @@ export default {
   reloadGraphs,
   togglePlotControls,
   getPlotOptions,
+  
+  makeGraphs,
 }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -328,8 +328,14 @@ function makeGraphs(vm, data, routepath) {
         //   console.log('WARNING: different numbers of plots and legends: ' + n_plots + ' vs. ' + n_legends)
         // }
         
+        // Initialize the indices for the first occurrences of graph types.
+        let firstOutcomeInd = -1
+        let firstBudgetInd = -1
+        let firstCoverageInd = -1
+        let firstCascadeInd = -1
+        
         // Loop over all of the plots...
-        for (var index = 0; index <= n_plots; index++) {
+        for (var index = 0; index < n_plots; index++) {
           console.log('Rendering plot ' + index)
           var figlabel    = 'fig' + index
           var figdiv  = document.getElementById(figlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
@@ -392,38 +398,64 @@ function makeGraphs(vm, data, routepath) {
           //   }
           //
           // }
+          
+          // Flag the first occurrence of the type if we encounter it.
+          if ((graphtypes[index] == "framework") && (firstOutcomeInd == -1)) {
+            firstOutcomeInd = index
+          }
+          if ((graphtypes[index] == "budget") && (firstBudgetInd == -1)) {
+            firstBudgetInd = index
+          }
+          if ((graphtypes[index] == "coverage") && (firstCoverageInd == -1)) {
+            firstCoverageInd = index
+          }
+          if ((graphtypes[index] == "cascade") && (firstCascadeInd == -1)) {
+            firstCascadeInd = index
+          }          
+              
           vm.showGraphDivs[index] = true;
         } // end of for loop
         
-        // Add headings after all graphs are up.
+        // Add headings after all graphs are up.        
+        var newItem
+        var textnode
+        var destdiv
         
         // Add a the cascade graphs heading.
-        var newItem = document.createElement("H2")
-        var textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
-        newItem.appendChild(textnode)
-        var figdiv = document.getElementById("fig0")
-        figdiv.insertBefore(newItem, figdiv.childNodes[0])
+        if (firstCascadeInd != -1) {
+          newItem = document.createElement("H2")
+          textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
+          newItem.appendChild(textnode)
+          var figdiv = document.getElementById("fig" + firstCascadeInd)
+          figdiv.insertBefore(newItem, figdiv.childNodes[0])
+        }
 
         // Add the outcome graphs heading.
-        newItem = document.createElement("H2")
-        textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
-        newItem.appendChild(textnode)
-        var destdiv = document.getElementById("figcontainer1").parentNode
-        destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        if (firstOutcomeInd != -1) {
+          newItem = document.createElement("H2")
+          textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
+          newItem.appendChild(textnode)
+          destdiv = document.getElementById("figcontainer" + firstOutcomeInd).parentNode
+          destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        }
         
         // Add the budget graphs heading.
-        newItem = document.createElement("H2")
-        textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
-        newItem.appendChild(textnode)
-        var destdiv = document.getElementById("figcontainer29").parentNode
-        destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        if (firstBudgetInd != -1) {
+          newItem = document.createElement("H2")
+          textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
+          newItem.appendChild(textnode)
+          destdiv = document.getElementById("figcontainer" + firstBudgetInd).parentNode
+          destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        }
         
-        // Add the outcome graphs heading.
-        newItem = document.createElement("H2")
-        textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
-        newItem.appendChild(textnode)
-        var destdiv = document.getElementById("figcontainer30").parentNode
-        destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        // Add the coverage graphs heading.
+        if (firstCoverageInd != -1) {
+          newItem = document.createElement("H2")
+          textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
+          newItem.appendChild(textnode)
+          destdiv = document.getElementById("figcontainer" + firstCoverageInd).parentNode
+          destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        }
         
         sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do
       })

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -299,18 +299,24 @@ function reloadGraphs(vm, project_id, cache_id, showNoCacheError, iscalibration,
 }
 
 function makeGraphs(vm, data, routepath) {
-  if (typeof d3 === 'undefined'){
+  // Exit if the d3 library is not not included.
+  if (typeof d3 === 'undefined'){ 
     console.log("please include d3 to use the makeGraphs function")
     return false;
   }
-  if (routepath && routepath !== vm.$route.path) { // Don't render graphs if we've changed page
+  
+  // Don't render graphs if we've changed page
+  if (routepath && routepath !== vm.$route.path) { 
     console.log('Not rendering graphs since route changed: ' + routepath + ' vs. ' + vm.$route.path)
   }
-  else { // Proceed...
+  
+  // Otherwise, proceed...
+  else {
     let waitingtime = 0.5
     var graphdata = data.graphs
-    var graphtypes = data.types
     // var legenddata = data.legends
+    var graphtypes = data.types
+    
     sciris.status.start(vm) // Start indicating progress.
     vm.hasGraphs = true
     sciris.utils.sleep(waitingtime * 1000)
@@ -321,6 +327,8 @@ function makeGraphs(vm, data, routepath) {
         // if (n_plots !== n_legends) {
         //   console.log('WARNING: different numbers of plots and legends: ' + n_plots + ' vs. ' + n_legends)
         // }
+        
+        // Loop over all of the plots...
         for (var index = 0; index <= n_plots; index++) {
           console.log('Rendering plot ' + index)
           var figlabel    = 'fig' + index
@@ -360,7 +368,7 @@ function makeGraphs(vm, data, routepath) {
             if (graphtypes[index] == "cascade" || graphtypes[index] == "budget") {
               sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
                 fig.axes[0].axisList[0].props.tickformat_formatter = "fixed"         
-              }, true);
+              }, true)
               
             // Otherwise (if we are dealing with a framework or coverage figure)...
             } else {
@@ -368,7 +376,7 @@ function makeGraphs(vm, data, routepath) {
                 fig.setXTicks(6, function (d) {
                   return d3.format('.0f')(d);
                 });
-              }, true);                
+              }, true)
             }
           } catch (error) {
             console.log('Could not plot graph: ' + error.message)
@@ -385,7 +393,7 @@ function makeGraphs(vm, data, routepath) {
           //
           // }
           vm.showGraphDivs[index] = true;
-        }
+        } // end of for loop
         sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do
       })
   }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -309,6 +309,7 @@ function makeGraphs(vm, data, routepath) {
   else { // Proceed...
     let waitingtime = 0.5
     var graphdata = data.graphs
+    var graphtypes = data.types
     // var legenddata = data.legends
     sciris.status.start(vm) // Start indicating progress.
     vm.hasGraphs = true
@@ -355,14 +356,19 @@ function makeGraphs(vm, data, routepath) {
 
           // Draw figures
           try {
-            sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
-              fig.setXTicks(6, function (d) {
-                return d3.format('.0f')(d);
-              });
-              // fig.setYTicks(null, function (d) { // Looks too weird with 500m for 0.5
-              //   return d3.format('.2s')(d);
-              // });
-            }, true);
+            if (graphtypes[index] == "cascade" || graphtypes[index] == "budget") {
+              sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
+                fig.axes[0].axisList[0].props.tickformat_formatter = "index"
+                fig.axes[0].axisList[0].props.tickformat = ["a", "b", "c"]
+                fig.axes[0].axisList[0].props.tickvalues = [0, 1, 2]
+              }, true);
+            } else {
+              sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
+                fig.setXTicks(6, function (d) {
+                  return d3.format('.0f')(d);
+                });
+              }, true);                
+            }
           } catch (error) {
             console.log('Could not plot graph: ' + error.message)
           }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -359,19 +359,7 @@ function makeGraphs(vm, data, routepath) {
             // If we are dealing with a cascade or budget figure... 
             if (graphtypes[index] == "cascade" || graphtypes[index] == "budget") {
               sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
-/*                fig.axes[0].axisList[0].props.tickformat_formatter = "index"
-                fig.axes[0].axisList[0].props.tickformat = ["a", "b", "c"]
-                fig.axes[0].axisList[0].props.tickvalues = [0, 1, 2] */
-/*                fig.setXTicks(6, function (d) {
-                  return d3.format('.0f')(d);
-                }); */
-                fig.axes[0].axisList[0].props.tickformat_formatter = "index"
-                console.log('tickformat_formatter:', fig.axes[0].axisList[0].props.tickformat_formatter)
-                console.log('tickformat:', fig.axes[0].axisList[0].props.tickformat)
-                console.log('tickvalues:', fig.axes[0].axisList[0].props.tickvalues)               
-/*                fig.setXTicks(6, function (d) {
-                  return d;
-                }); */          
+                fig.axes[0].axisList[0].props.tickformat_formatter = "fixed"         
               }, true);
               
             // Otherwise (if we are dealing with a framework or coverage figure)...

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -477,50 +477,58 @@ function makeGraphs(vm, data, routepath) {
         
         // Add the outcome graphs heading.
         if (firstOutcomeInd != -1) {
-          newItem = document.createElement("BR")
+          newItem = document.createElement("DIV")
+          newItem.classList.add("graph-header")          
+          newItem2 = document.createElement("BR")
+          newItem.appendChild(newItem2)      
           newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
           newItem2.appendChild(textnode)
-          newItem2.classList.add("graph-header")
+          newItem.appendChild(newItem2)
           destdiv = outcomeGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, outcomeGraphsDivs[0])
-          destdiv.insertBefore(newItem2, outcomeGraphsDivs[0])
         }
         
         // Add the budget graphs heading.
         if (firstBudgetInd != -1) {
-          newItem = document.createElement("BR")
+          newItem = document.createElement("DIV")
+          newItem.classList.add("graph-header")       
+          newItem2 = document.createElement("BR")
+          newItem.appendChild(newItem2)        
           newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
           newItem2.appendChild(textnode)
-          newItem2.classList.add("graph-header")
+          newItem.appendChild(newItem2)
           destdiv = budgetGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, budgetGraphsDivs[0])
-          destdiv.insertBefore(newItem2, budgetGraphsDivs[0])
         }
         
         // Add the coverage graphs heading.
         if (firstCoverageInd != -1) {
-          newItem = document.createElement("BR")
+          newItem = document.createElement("DIV")
+          newItem.classList.add("graph-header")   
+          newItem2 = document.createElement("BR")
+          newItem.appendChild(newItem2)
           newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
           newItem2.appendChild(textnode)
-          newItem2.classList.add("graph-header")
+          newItem.appendChild(newItem2)
           destdiv = coverageGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, coverageGraphsDivs[0])
-          destdiv.insertBefore(newItem2, coverageGraphsDivs[0])
         }
         
         // Add a the cascade graphs heading.
         if (firstCascadeInd != -1) {
-          newItem = document.createElement("BR")
+          newItem = document.createElement("DIV")
+          newItem.classList.add("graph-header")   
+          newItem2 = document.createElement("BR")
+          newItem.appendChild(newItem2)
           newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
           newItem2.appendChild(textnode)
-          newItem2.classList.add("graph-header")
+          newItem.appendChild(newItem2)
           destdiv = cascadeGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, cascadeGraphsDivs[0])
-          destdiv.insertBefore(newItem2, cascadeGraphsDivs[0])
         }
         
         sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -313,9 +313,9 @@ function makeGraphs(vm, data, routepath) {
   // Otherwise, proceed...
   else {
     let waitingtime = 0.5
-    var graphdata = data.graphs
-    // var legenddata = data.legends
-    var graphtypes = data.types
+    let graphdata = data.graphs
+    // let legenddata = data.legends
+    let graphtypes = data.types
     
     sciris.status.start(vm) // Start indicating progress.
     vm.hasGraphs = true
@@ -328,8 +328,34 @@ function makeGraphs(vm, data, routepath) {
         //   console.log('WARNING: different numbers of plots and legends: ' + n_plots + ' vs. ' + n_legends)
         // }
         
+        // Remove all existing plots for all of the graph types.
+        let outcomeGraphsDivs = document.getElementsByClassName("outcome-graphs")
+        if (outcomeGraphsDivs) {
+          while (outcomeGraphsDivs[0].children[0]) {
+            outcomeGraphsDivs[0].removeChild(outcomeGraphsDivs[0].children[0])
+          }
+        }
+        let budgetGraphsDivs = document.getElementsByClassName("budget-graphs")
+        if (budgetGraphsDivs) {
+          while (budgetGraphsDivs[0].children[0]) {
+            budgetGraphsDivs[0].removeChild(budgetGraphsDivs[0].children[0])
+          }
+        }        
+        let coverageGraphsDivs = document.getElementsByClassName("coverage-graphs")
+        if (coverageGraphsDivs) {
+          while (coverageGraphsDivs[0].children[0]) {
+            coverageGraphsDivs[0].removeChild(coverageGraphsDivs[0].children[0])
+          }
+        }        
+        let cascadeGraphsDivs = document.getElementsByClassName("cascade-graphs")
+        if (cascadeGraphsDivs) {
+          while (cascadeGraphsDivs[0].children[0]) {
+            cascadeGraphsDivs[0].removeChild(cascadeGraphsDivs[0].children[0])
+          }
+        }
+        
         // Remove all existing graph-header (class) elements.
-        var headers = document.getElementsByClassName("graph-header")
+        let headers = document.getElementsByClassName("graph-header")
         while (headers[0]) {
           headers[0].parentNode.removeChild(headers[0])
         }
@@ -342,39 +368,61 @@ function makeGraphs(vm, data, routepath) {
         
         // Loop over all of the plots...
         for (var index = 0; index < n_plots; index++) {
-          console.log('Rendering plot ' + index)
-          var figlabel    = 'fig' + index
-          var figdiv  = document.getElementById(figlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
-          if (figdiv) {
-/*            while (figdiv.firstChild) {
-              figdiv.removeChild(figdiv.firstChild);
-            } */
-          } else {
-            console.log('WARNING: figdiv not found: ' + figlabel)
+          console.log('Rendering plot ' + index + '. Type is ' + graphtypes[index])
+          var figlabel = 'fig' + index
+          var newfigdiv
+          var figcontainerlabel = 'figcontainer' + index
+          var newfigcontdiv
+          
+          if ((graphtypes[index] == "framework") && (outcomeGraphsDivs)) {
+            // Create the figure container and put it in the outcome graphs div.
+            newfigcontdiv = document.createElement("DIV")
+            newfigcontdiv.id = figcontainerlabel
+            newfigcontdiv.style.display = 'flex'
+            newfigcontdiv.style.justifyContent = 'flex-start'
+            newfigcontdiv.style.padding = '5px'
+            newfigcontdiv.style.border = '1px solid #ddd'
+            outcomeGraphsDivs[0].appendChild(newfigcontdiv)
+            
+            // Create a new figure and put it in that fig container.
+            newfigdiv = document.createElement("DIV")
+            newfigdiv.id = figlabel
+            newfigcontdiv.appendChild(newfigdiv)           
+          } else if ((graphtypes[index] == "budget") && (budgetGraphsDivs)) {
+            // Create the figure container and put it in the budget graphs div.
+            newfigcontdiv = document.createElement("DIV")
+            newfigcontdiv.id = figcontainerlabel
+            newfigcontdiv.style.display = 'flex'
+            newfigcontdiv.style.justifyContent = 'flex-start'
+            newfigcontdiv.style.padding = '5px'
+            newfigcontdiv.style.border = '1px solid #ddd'
+            budgetGraphsDivs[0].appendChild(newfigcontdiv)
+            
+            // Create a new figure and put it in that fig container.
+            newfigdiv = document.createElement("DIV")
+            newfigdiv.id = figlabel
+            newfigcontdiv.appendChild(newfigdiv)           
+          } else if ((graphtypes[index] == "coverage") && (coverageGraphsDivs)) {
+            // Create the figure container and put it in the coverage graphs div.
+            newfigcontdiv = document.createElement("DIV")
+            newfigcontdiv.id = figcontainerlabel
+            newfigcontdiv.style.display = 'flex'
+            newfigcontdiv.style.justifyContent = 'flex-start'
+            newfigcontdiv.style.padding = '5px'
+            newfigcontdiv.style.border = '1px solid #ddd'
+            coverageGraphsDivs[0].appendChild(newfigcontdiv)
+            
+            // Create a new figure and put it in that fig container.
+            newfigdiv = document.createElement("DIV")
+            newfigdiv.id = figlabel
+            newfigcontdiv.appendChild(newfigdiv)           
+          } else if ((graphtypes[index] == "cascade") && (cascadeGraphsDivs)) {
+            newfigdiv = document.createElement("DIV")
+            newfigdiv.id = figlabel
+            cascadeGraphsDivs[0].appendChild(newfigdiv)           
           }
 
-          // Show figure containers
-          if (index >= 1 && index < n_plots) {
-            var figcontainerlabel = 'figcontainer' + index
-            var figcontainerdiv = document.getElementById(figcontainerlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
-            if (figcontainerdiv) {
-              figcontainerdiv.style.display = 'flex'
-            } else {
-              console.log('WARNING: figcontainerdiv not found: ' + figcontainerlabel)
-            }
-
-            // var legendlabel = 'legend' + index
-            // var legenddiv  = document.getElementById(legendlabel);
-            // if (legenddiv) {
-            //   while (legenddiv.firstChild) {
-            //     legenddiv.removeChild(legenddiv.firstChild);
-            //   }
-            // } else {
-            //   console.log('WARNING: legenddiv not found: ' + legendlabel)
-            // }
-          }
-
-          // Draw the figure
+          // Draw the mpld3 figure into the figN div where it belongs.
           try {
             // If we are dealing with a cascade or budget figure... 
             if (graphtypes[index] == "cascade" || graphtypes[index] == "budget") {
@@ -427,24 +475,14 @@ function makeGraphs(vm, data, routepath) {
         var textnode
         var destdiv
         
-        // Add a the cascade graphs heading.
-        if (firstCascadeInd != -1) {
-          newItem = document.createElement("H2")
-          textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
-          newItem.appendChild(textnode)
-          newItem.classList.add("graph-header")
-          var figdiv = document.getElementById("fig" + firstCascadeInd)
-          figdiv.insertBefore(newItem, figdiv.childNodes[0])
-        }
-
         // Add the outcome graphs heading.
         if (firstOutcomeInd != -1) {
           newItem = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
           newItem.appendChild(textnode)
           newItem.classList.add("graph-header")
-          destdiv = document.getElementById("figcontainer" + firstOutcomeInd).parentNode
-          destdiv.insertBefore(newItem, destdiv.childNodes[0])
+          destdiv = outcomeGraphsDivs[0].parentNode         
+          destdiv.insertBefore(newItem, outcomeGraphsDivs[0])
         }
         
         // Add the budget graphs heading.
@@ -453,8 +491,8 @@ function makeGraphs(vm, data, routepath) {
           textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
           newItem.appendChild(textnode)
           newItem.classList.add("graph-header")
-          destdiv = document.getElementById("figcontainer" + firstBudgetInd).parentNode
-          destdiv.insertBefore(newItem, destdiv.childNodes[0])
+          destdiv = budgetGraphsDivs[0].parentNode         
+          destdiv.insertBefore(newItem, budgetGraphsDivs[0])
         }
         
         // Add the coverage graphs heading.
@@ -463,8 +501,18 @@ function makeGraphs(vm, data, routepath) {
           textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
           newItem.appendChild(textnode)
           newItem.classList.add("graph-header")
-          destdiv = document.getElementById("figcontainer" + firstCoverageInd).parentNode
-          destdiv.insertBefore(newItem, destdiv.childNodes[0])
+          destdiv = coverageGraphsDivs[0].parentNode         
+          destdiv.insertBefore(newItem, coverageGraphsDivs[0])
+        }
+        
+        // Add a the cascade graphs heading.
+        if (firstCascadeInd != -1) {
+          newItem = document.createElement("H2")
+          textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
+          newItem.appendChild(textnode)
+          newItem.classList.add("graph-header")
+          destdiv = cascadeGraphsDivs[0].parentNode         
+          destdiv.insertBefore(newItem, cascadeGraphsDivs[0])
         }
         
         sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -328,6 +328,12 @@ function makeGraphs(vm, data, routepath) {
         //   console.log('WARNING: different numbers of plots and legends: ' + n_plots + ' vs. ' + n_legends)
         // }
         
+        // Remove all existing graph-header (class) elements.
+        var headers = document.getElementsByClassName("graph-header")
+        while (headers[0]) {
+          headers[0].parentNode.removeChild(headers[0])
+        }
+        
         // Initialize the indices for the first occurrences of graph types.
         let firstOutcomeInd = -1
         let firstBudgetInd = -1
@@ -340,15 +346,15 @@ function makeGraphs(vm, data, routepath) {
           var figlabel    = 'fig' + index
           var figdiv  = document.getElementById(figlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
           if (figdiv) {
-            while (figdiv.firstChild) {
+/*            while (figdiv.firstChild) {
               figdiv.removeChild(figdiv.firstChild);
-            }
+            } */
           } else {
             console.log('WARNING: figdiv not found: ' + figlabel)
           }
 
           // Show figure containers
-          if (index>=1 && index<n_plots) {
+          if (index >= 1 && index < n_plots) {
             var figcontainerlabel = 'figcontainer' + index
             var figcontainerdiv = document.getElementById(figcontainerlabel); // CK: Not sure if this is necessary? To ensure the div is clear first
             if (figcontainerdiv) {
@@ -389,7 +395,7 @@ function makeGraphs(vm, data, routepath) {
           }
 
           // Draw legends
-          // if (index>=1 && index<n_plots) {
+          // if (index >= 1 && index < n_plots) {
           //   try {
           //     mpld3.draw_figure(legendlabel, legenddata[index], function (fig, element) {
           //     });
@@ -426,6 +432,7 @@ function makeGraphs(vm, data, routepath) {
           newItem = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
           newItem.appendChild(textnode)
+          newItem.classList.add("graph-header")
           var figdiv = document.getElementById("fig" + firstCascadeInd)
           figdiv.insertBefore(newItem, figdiv.childNodes[0])
         }
@@ -435,6 +442,7 @@ function makeGraphs(vm, data, routepath) {
           newItem = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
           newItem.appendChild(textnode)
+          newItem.classList.add("graph-header")
           destdiv = document.getElementById("figcontainer" + firstOutcomeInd).parentNode
           destdiv.insertBefore(newItem, destdiv.childNodes[0])
         }
@@ -444,6 +452,7 @@ function makeGraphs(vm, data, routepath) {
           newItem = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
           newItem.appendChild(textnode)
+          newItem.classList.add("graph-header")
           destdiv = document.getElementById("figcontainer" + firstBudgetInd).parentNode
           destdiv.insertBefore(newItem, destdiv.childNodes[0])
         }
@@ -453,6 +462,7 @@ function makeGraphs(vm, data, routepath) {
           newItem = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
           newItem.appendChild(textnode)
+          newItem.classList.add("graph-header")
           destdiv = document.getElementById("figcontainer" + firstCoverageInd).parentNode
           destdiv.insertBefore(newItem, destdiv.childNodes[0])
         }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -354,14 +354,27 @@ function makeGraphs(vm, data, routepath) {
             // }
           }
 
-          // Draw figures
+          // Draw the figure
           try {
+            // If we are dealing with a cascade or budget figure... 
             if (graphtypes[index] == "cascade" || graphtypes[index] == "budget") {
               sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
-                fig.axes[0].axisList[0].props.tickformat_formatter = "index"
+/*                fig.axes[0].axisList[0].props.tickformat_formatter = "index"
                 fig.axes[0].axisList[0].props.tickformat = ["a", "b", "c"]
-                fig.axes[0].axisList[0].props.tickvalues = [0, 1, 2]
+                fig.axes[0].axisList[0].props.tickvalues = [0, 1, 2] */
+/*                fig.setXTicks(6, function (d) {
+                  return d3.format('.0f')(d);
+                }); */
+                fig.axes[0].axisList[0].props.tickformat_formatter = "index"
+                console.log('tickformat_formatter:', fig.axes[0].axisList[0].props.tickformat_formatter)
+                console.log('tickformat:', fig.axes[0].axisList[0].props.tickformat)
+                console.log('tickvalues:', fig.axes[0].axisList[0].props.tickvalues)               
+/*                fig.setXTicks(6, function (d) {
+                  return d;
+                }); */          
               }, true);
+              
+            // Otherwise (if we are dealing with a framework or coverage figure)...
             } else {
               sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
                 fig.setXTicks(6, function (d) {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -394,6 +394,37 @@ function makeGraphs(vm, data, routepath) {
           // }
           vm.showGraphDivs[index] = true;
         } // end of for loop
+        
+        // Add headings after all graphs are up.
+        
+        // Add a the cascade graphs heading.
+        var newItem = document.createElement("H2")
+        var textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
+        newItem.appendChild(textnode)
+        var figdiv = document.getElementById("fig0")
+        figdiv.insertBefore(newItem, figdiv.childNodes[0])
+
+        // Add the outcome graphs heading.
+        newItem = document.createElement("H2")
+        textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
+        newItem.appendChild(textnode)
+        var destdiv = document.getElementById("figcontainer1").parentNode
+        destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        
+        // Add the budget graphs heading.
+        newItem = document.createElement("H2")
+        textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
+        newItem.appendChild(textnode)
+        var destdiv = document.getElementById("figcontainer29").parentNode
+        destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        
+        // Add the outcome graphs heading.
+        newItem = document.createElement("H2")
+        textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
+        newItem.appendChild(textnode)
+        var destdiv = document.getElementById("figcontainer30").parentNode
+        destdiv.insertBefore(newItem, destdiv.childNodes[0])
+        
         sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do
       })
   }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -471,48 +471,56 @@ function makeGraphs(vm, data, routepath) {
         } // end of for loop
         
         // Add headings after all graphs are up.        
-        var newItem
+        var newItem, newItem2
         var textnode
         var destdiv
         
         // Add the outcome graphs heading.
         if (firstOutcomeInd != -1) {
-          newItem = document.createElement("H2")
+          newItem = document.createElement("BR")
+          newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Outcome Plots")
-          newItem.appendChild(textnode)
-          newItem.classList.add("graph-header")
+          newItem2.appendChild(textnode)
+          newItem2.classList.add("graph-header")
           destdiv = outcomeGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, outcomeGraphsDivs[0])
+          destdiv.insertBefore(newItem2, outcomeGraphsDivs[0])
         }
         
         // Add the budget graphs heading.
         if (firstBudgetInd != -1) {
-          newItem = document.createElement("H2")
+          newItem = document.createElement("BR")
+          newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Program Spending Plots")
-          newItem.appendChild(textnode)
-          newItem.classList.add("graph-header")
+          newItem2.appendChild(textnode)
+          newItem2.classList.add("graph-header")
           destdiv = budgetGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, budgetGraphsDivs[0])
+          destdiv.insertBefore(newItem2, budgetGraphsDivs[0])
         }
         
         // Add the coverage graphs heading.
         if (firstCoverageInd != -1) {
-          newItem = document.createElement("H2")
+          newItem = document.createElement("BR")
+          newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Program Coverage Plots")
-          newItem.appendChild(textnode)
-          newItem.classList.add("graph-header")
+          newItem2.appendChild(textnode)
+          newItem2.classList.add("graph-header")
           destdiv = coverageGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, coverageGraphsDivs[0])
+          destdiv.insertBefore(newItem2, coverageGraphsDivs[0])
         }
         
         // Add a the cascade graphs heading.
         if (firstCascadeInd != -1) {
-          newItem = document.createElement("H2")
+          newItem = document.createElement("BR")
+          newItem2 = document.createElement("H2")
           textnode = document.createTextNode("\u00A0\u00A0Care Cascades")
-          newItem.appendChild(textnode)
-          newItem.classList.add("graph-header")
+          newItem2.appendChild(textnode)
+          newItem2.classList.add("graph-header")
           destdiv = cascadeGraphsDivs[0].parentNode         
           destdiv.insertBefore(newItem, cascadeGraphsDivs[0])
+          destdiv.insertBefore(newItem2, cascadeGraphsDivs[0])
         }
         
         sciris.status.succeed(vm, 'Graphs created') // CK: This should be a promise, otherwise this appears before the graphs do

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-08
+Last update: 2019-05-17
 -->
 
 <template>
@@ -118,7 +118,15 @@ Last update: 2019-05-08
           <div class="calib-title">
             <help reflink="bl-results" label="Results"></help>
             <div>
-
+              <template v-if="simCascades.length>1">
+                <b>Cascade: &nbsp;</b>
+                <select v-model="activeCascade" @change="reloadGraphs(true)">
+                  <option v-for='cascade in simCascades'>
+                    {{ cascade }}
+                  </option>
+                </select>
+              </template>
+              &nbsp;&nbsp;&nbsp;
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in simYears'>

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-17
+Last update: 2019-05-18
 -->
 
 <template>
@@ -155,7 +155,6 @@ Last update: 2019-05-17
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-                <h2>&nbsp;&nbsp;Outcome Calibration Plots</h2>
                 <div class="other-graphs">
                   <div v-for="index in placeholders">
                     <div :id="'figcontainer'+index" class="figcontainer" v-show="showGraphDivs[index]">
@@ -170,7 +169,6 @@ Last update: 2019-05-17
                 </div>
 
                 <!-- ### Start: Cascade plot ### -->
-                <h2>&nbsp;&nbsp;Care Cascades</h2>
                 <div class="featured-graphs">
                   <div :id="'fig0'">
                     <!-- mpld3 content goes here, no legend for it -->

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-22
+Last update: 2019-05-23
 -->
 
 <template>
@@ -142,8 +142,8 @@ Last update: 2019-05-22
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
               <button class="btn" @click="reloadGraphs(true)">Refresh</button>
-              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true">Show plot selection</button>
-              <button v-else class="btn" @click="showPlotControls = false">Hide plot selection</button>                
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true; scaleFigs(0.8)">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false; scaleFigs(1.0)">Hide plot selection</button>                
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(serverDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="$globaltool=='tb'" -->

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-21
+Last update: 2019-05-22
 -->
 
 <template>
@@ -141,6 +141,9 @@ Last update: 2019-05-21
               <button class="btn btn-icon" @click="scaleFigs(0.9)" data-tooltip="Zoom out">&ndash;</button>
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
+              <button class="btn" @click="reloadGraphs(true)">Refresh</button>
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false">Hide plot selection</button>                
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(serverDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="$globaltool=='tb'" -->

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-18
+Last update: 2019-05-21
 -->
 
 <template>
@@ -155,27 +155,18 @@ Last update: 2019-05-18
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-                <div class="other-graphs">
-                  <div v-for="index in placeholders">
-                    <div :id="'figcontainer'+index" class="figcontainer" v-show="showGraphDivs[index]">
-                      <div :id="'fig'+index" class="calib-graph">
-                        <!--mpld3 content goes here-->
-                      </div>
-                      <!--<div style="display:inline-block">-->
-                      <!--<button class="btn __bw btn-icon" @click="maximize(index)" data-tooltip="Show legend"><i class="ti-menu-alt"></i></button>-->
-                      <!--</div>-->
-                    </div>
-                  </div>
+                <div class="outcome-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>               
+                <div class="budget-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-
-                <!-- ### Start: Cascade plot ### -->
-                <div class="featured-graphs">
-                  <div :id="'fig0'">
-                    <!-- mpld3 content goes here, no legend for it -->
-                  </div>
+                <div class="coverage-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-                <!-- ### End: Cascade plot ### -->
-
+                <div class="cascade-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>
               </div> <!-- ### End: calib-graphs ### -->
             </div>
             <!-- ### End: plots ### -->

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -77,7 +77,7 @@ Last update: 2019-05-17
             <div>
               <template v-if="simCascades.length>1">
                 <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(true)">
+                <select v-model="activeCascade" @change="reloadGraphs(displayResultDatastoreId, true)">
                   <option v-for='cascade in simCascades'>
                     {{ cascade }}
                   </option>

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-08
+Last update: 2019-05-17
 -->
 
 <template>
@@ -75,7 +75,15 @@ Last update: 2019-05-08
           <div class="calib-title">
             <help reflink="results-plots" label="Results"></help>
             <div>
-
+              <template v-if="simCascades.length>1">
+                <b>Cascade: &nbsp;</b>
+                <select v-model="activeCascade" @change="reloadGraphs(true)">
+                  <option v-for='cascade in simCascades'>
+                    {{ cascade }}
+                  </option>
+                </select>
+              </template>
+              &nbsp;&nbsp;&nbsp;
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(displayResultDatastoreId, true)">
                 <option v-for='year in projectionYears'>

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-21
+Last update: 2019-05-22
 -->
 
 <template>
@@ -100,6 +100,9 @@ Last update: 2019-05-21
               <button class="btn btn-icon" @click="scaleFigs(0.9)" data-tooltip="Zoom out">&ndash;</button>
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
+              <button class="btn" @click="reloadGraphs(displayResultDatastoreId, true)">Refresh</button>
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false">Hide plot selection</button>              
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(displayResultDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="this.$globaltool=='tb'" -->

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-18
+Last update: 2019-05-21
 -->
 
 <template>
@@ -114,27 +114,18 @@ Last update: 2019-05-18
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-                <div class="other-graphs">
-                  <div v-for="index in placeholders">
-                    <div :id="'figcontainer'+index" style="display:flex; justify-content:flex-start; padding:5px; border:1px solid #ddd" v-show="showGraphDivs[index]">
-                      <div :id="'fig'+index" class="calib-graph">
-                        <!--mpld3 content goes here-->
-                      </div>
-                      <!--<div style="display:inline-block">-->
-                      <!--<button class="btn __bw btn-icon" @click="maximize(index)" data-tooltip="Show legend"><i class="ti-menu-alt"></i></button>-->
-                      <!--</div>-->
-                    </div>
-                  </div>
+                <div class="outcome-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>               
+                <div class="budget-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-
-                <!-- ### Start: Cascade plot ### -->
-                <div class="featured-graphs">
-                  <div :id="'fig0'">
-                    <!-- mpld3 content goes here, no legend for it -->
-                  </div>
+                <div class="coverage-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-                <!-- ### End: Cascade plot ### -->
-
+                <div class="cascade-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>
               </div> <!-- ### End: calib-graphs ### -->
             </div>
             <!-- ### End: plots ### -->

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-17
+Last update: 2019-05-18
 -->
 
 <template>
@@ -114,7 +114,6 @@ Last update: 2019-05-17
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-                <h2>&nbsp;&nbsp;Outcome, Budget, and Coverage Plots</h2>
                 <div class="other-graphs">
                   <div v-for="index in placeholders">
                     <div :id="'figcontainer'+index" style="display:flex; justify-content:flex-start; padding:5px; border:1px solid #ddd" v-show="showGraphDivs[index]">
@@ -129,7 +128,6 @@ Last update: 2019-05-17
                 </div>
 
                 <!-- ### Start: Cascade plot ### -->
-                <h2>&nbsp;&nbsp;Care Cascades</h2>
                 <div class="featured-graphs">
                   <div :id="'fig0'">
                     <!-- mpld3 content goes here, no legend for it -->

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-22
+Last update: 2019-05-23
 -->
 
 <template>
@@ -101,8 +101,8 @@ Last update: 2019-05-22
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
               <button class="btn" @click="reloadGraphs(displayResultDatastoreId, true)">Refresh</button>
-              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true">Show plot selection</button>
-              <button v-else class="btn" @click="showPlotControls = false">Hide plot selection</button>              
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true; scaleFigs(0.8)">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false; scaleFigs(1.0)">Hide plot selection</button>              
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(displayResultDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="this.$globaltool=='tb'" -->

--- a/src/tb/app/ProjectsPage.vue
+++ b/src/tb/app/ProjectsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Manage projects page
 
-Last update: 2018oct04
+Last update: 2019may16
 -->
 
 <template>
@@ -97,7 +97,7 @@ Last update: 2018oct04
             <td style="text-align:left">
               <button 
                 class="btn __blue btn-icon" 
-                @click="uploadDatabook(projectSummary.project.id)" 
+                @click="uploadDatabookModal(projectSummary.project.id)" 
                 data-tooltip="Upload">  
                 <i class="ti-upload"></i>
               </button>
@@ -118,7 +118,7 @@ Last update: 2018oct04
               </button>
               <button 
                 class="btn __blue btn-icon" 
-                @click="uploadProgbook(projectSummary.project.id)" 
+                @click="uploadProgbookModal(projectSummary.project.id)" 
                 data-tooltip="Upload">  
                 <i class="ti-upload"></i>
               </button>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-21
+Last update: 2019-05-22
 -->
 
 <template>
@@ -101,6 +101,9 @@ Last update: 2019-05-21
               <button class="btn btn-icon" @click="scaleFigs(0.9)" data-tooltip="Zoom out">&ndash;</button>
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
+              <button class="btn" @click="reloadGraphs(true)">Refresh</button>
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false">Hide plot selection</button>              
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(serverDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="$globaltool=='tb'" -->

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-17
+Last update: 2019-05-21
 -->
 
 <template>
@@ -115,27 +115,18 @@ Last update: 2019-05-17
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-                <div class="other-graphs">              
-                  <div v-for="index in placeholders">
-                    <div :id="'figcontainer'+index" style="display:flex; justify-content:flex-start; padding:5px; border:1px solid #ddd" v-show="showGraphDivs[index]">
-                      <div :id="'fig'+index" class="calib-graph">
-                        <!--mpld3 content goes here-->
-                      </div>
-                      <!--<div style="display:inline-block">-->
-                      <!--<button class="btn __bw btn-icon" @click="maximize(index)" data-tooltip="Show legend"><i class="ti-menu-alt"></i></button>-->
-                      <!--</div>-->
-                    </div>
-                  </div>
+                <div class="outcome-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>               
+                <div class="budget-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-
-                <!-- ### Start: Cascade plot ### -->            
-                <div class="featured-graphs">
-                  <div :id="'fig0'">
-                    <!-- mpld3 content goes here, no legend for it -->
-                  </div>
+                <div class="coverage-graphs">
+                  <!-- multiple figs may be inserted here -->
                 </div>
-                <!-- ### End: Cascade plot ### -->
-
+                <div class="cascade-graphs">
+                  <!-- multiple figs may be inserted here -->
+                </div>
               </div> <!-- ### End: calib-graphs ### -->
             </div>
             <!-- ### End: plots ### -->

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-22
+Last update: 2019-05-23
 -->
 
 <template>
@@ -102,8 +102,8 @@ Last update: 2019-05-22
               <button class="btn btn-icon" @click="scaleFigs(1.0)" data-tooltip="Reset zoom"><i class="ti-zoom-in"></i></button>
               <button class="btn btn-icon" @click="scaleFigs(1.1)" data-tooltip="Zoom in">+</button>&nbsp;&nbsp;&nbsp;
               <button class="btn" @click="reloadGraphs(true)">Refresh</button>
-              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true">Show plot selection</button>
-              <button v-else class="btn" @click="showPlotControls = false">Hide plot selection</button>              
+              <button v-if="!showPlotControls" class="btn" @click="showPlotControls = true; scaleFigs(0.8)">Show plot selection</button>
+              <button v-else class="btn" @click="showPlotControls = false; scaleFigs(1.0)">Hide plot selection</button>              
               <button class="btn" @click="exportGraphs()">Export graphs</button>
               <button class="btn" @click="exportResults(serverDatastoreId)">Export data</button>
               <button v-if="false" class="btn btn-icon" @click="togglePlotControls()"><i class="ti-settings"></i></button> <!-- When popups are working: v-if="$globaltool=='tb'" -->

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -115,7 +115,6 @@ Last update: 2019-05-17
             <!-- ### Start: plots ### -->
             <div class="calib-card-body">
               <div class="calib-graphs">
-                <h2>&nbsp;&nbsp;Outcome, Budget, and Coverage Plots</h2>
                 <div class="other-graphs">              
                   <div v-for="index in placeholders">
                     <div :id="'figcontainer'+index" style="display:flex; justify-content:flex-start; padding:5px; border:1px solid #ddd" v-show="showGraphDivs[index]">
@@ -129,8 +128,7 @@ Last update: 2019-05-17
                   </div>
                 </div>
 
-                <!-- ### Start: Cascade plot ### -->
-                <h2>&nbsp;&nbsp;Care Cascades</h2>              
+                <!-- ### Start: Cascade plot ### -->            
                 <div class="featured-graphs">
                   <div :id="'fig0'">
                     <!-- mpld3 content goes here, no legend for it -->

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-08
+Last update: 2019-05-17
 -->
 
 <template>
@@ -76,7 +76,15 @@ Last update: 2019-05-08
           <div class="calib-title">
             <help reflink="results-plots" label="Results"></help>
             <div>
-
+              <template v-if="simCascades.length>1">
+                <b>Cascade: &nbsp;</b>
+                <select v-model="activeCascade" @change="reloadGraphs(true)">
+                  <option v-for='cascade in simCascades'>
+                    {{ cascade }}
+                  </option>
+                </select>
+              </template>
+              &nbsp;&nbsp;&nbsp;
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in projectionYears'>


### PR DESCRIPTION
This PR makes some improvements primarily (though not exclusively) to graphing on the TB site, in preparation for the WB demo.  These include the following:
* The problem with bar graph x axis labels being numbers instead of the proper strings has been fixed.
* Cached results are cleared in a more intelligent way when new databooks or program books are uploaded.  This includes using a confirmation modal dialog to allow users to back out if they don't want to lose their cached results.
* The Cascade selection dropdown has been ported from Cascade site code into TB.
* The way that `makeGraphs()` works has been improved in a way that dispenses with hacky `placeholders` variable.  The version of `makeGraphs()` used is now in the `atomica_apps` repo instead of `sciris-js`, allowing the figure generation to be more specifically tailored to the TB (or Cascade) site.  The improvement simplifies the HTML code for the graphing pages, providing separate `div` elements for each of the types of graphs (outcome, budget, coverage, cascade).  `makeGraphs()` uses information passed back from the Python code about each graph's type to insert the graph into the correct `div`.
* Headers are now inserted into the display of graphs according to the graph types.
* A plot selection pane is now working on each of the graphing pages for the TB and Cascade sites.  This can be opened and closed using `Show plot selection` / `Hide plot selection` buttons.  In addition to the existing checkboxes to select or unselect particular outcome plots, there are now also checkboxes for selecting / deselecting all budget plots, all coverage plots, and all cascade plots.  If you click the `Refresh` button, the Python code will update which plots are created, and this in turn will update the graphs shown in the graphing pages.