### PR TITLE
Pre wb demo

### DIFF
--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1246,7 +1246,7 @@ def supported_framework_plots_func(framework):
         Output: {name:quantities}: a dict with all of the plot quantities in the framework keyed by name
     '''
     if 'plots' not in framework.sheets:
-        return sc.odict()
+        return (sc.odict(), sc.odict())
     else:
         df = framework.sheets['plots'][0]
         plots = sc.odict()

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1565,6 +1565,7 @@ def get_cascade_plots(proj, results=None, pops=None, year=None, plot_budget=Fals
 
     for cascade in proj.framework.cascades.keys():
         fig, table = at.plot_cascade(results, cascade=cascade, pops=pops, year=years, data=proj.data, show_table=False)
+        pl.title(cascade)
         figjsons.append(customize_fig(fig=fig, output=None, plotdata=None, xlims=None, figsize=None, is_epi=False))
         figs.append(fig)
         legends.append(sc.emptyfig()) # No figure, but still useful to have a plot

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1405,7 +1405,7 @@ def make_plots(proj, results, tool=None, year=None, pops=None, cascade=None, plo
         output['types'] += d['types']
 
     if showcascadeplots:
-        cascadeoutput, cascadefigs, cascadelegends = get_cascade_plot(proj, results, year=year, pops=pops, cascade=cascade, plot_budget=plot_budget)
+        cascadeoutput, cascadefigs, cascadelegends = get_cascade_plots(proj, results, year=year, pops=pops, cascade=cascade, plot_budget=plot_budget)
         append_plots(cascadeoutput,cascadefigs,cascadelegends)
 
     if calibration:
@@ -1545,10 +1545,12 @@ def get_coverage_plots(results):
     return output, figs, legends
 
 
-def get_cascade_plot(proj, results=None, pops=None, year=None, cascade=None, plot_budget=False):
+def get_cascade_plots(proj, results=None, pops=None, year=None, cascade=None, plot_budget=False):
     
-    if results is None: results = proj.results[-1]
-    if year    is None: year    = proj.settings.sim_end # Needed for plot_budget
+    if results is None:
+        results = proj.results[-1]
+    if year    is None:
+        year    = proj.settings.sim_end
     
     figs = []
     legends = []
@@ -1558,10 +1560,11 @@ def get_cascade_plot(proj, results=None, pops=None, year=None, cascade=None, plo
     for y in range(len(years)):
         years[y] = float(years[y]) # Ensure it's a float
 
-    fig,table = at.plot_cascade(results, cascade=cascade, pops=pops, year=years, data=proj.data, show_table=False)
-    figjsons.append(customize_fig(fig=fig, output=None, plotdata=None, xlims=None, figsize=None, is_epi=False))
-    figs.append(fig)
-    legends.append(sc.emptyfig()) # No figure, but still useful to have a plot
+    for thecascade in proj.framework.cascades.keys():
+        fig, table = at.plot_cascade(results, cascade=thecascade, pops=pops, year=years, data=proj.data, show_table=False)
+        figjsons.append(customize_fig(fig=fig, output=None, plotdata=None, xlims=None, figsize=None, is_epi=False))
+        figs.append(fig)
+        legends.append(sc.emptyfig()) # No figure, but still useful to have a plot
     
     for fig in legends: # Different enough to warrant its own block, although ugly
         try:
@@ -1573,13 +1576,20 @@ def get_cascade_plot(proj, results=None, pops=None, year=None, cascade=None, plo
         legendjsons.append(graph_dict)
         pl.close(fig)
     
-    jsondata,jsoncolors = get_json_cascade(results=results, data=proj.data)
-    output = {'graphs':figjsons, 'legends':legendjsons, 'table':table, 'jsondata':jsondata, 'jsoncolors':jsoncolors, 'types':['cascade']*len(figjsons)}
+    jsondata, jsoncolors = get_json_cascade(results=results, data=proj.data)
+    output = {
+        'graphs': figjsons,
+        'legends': legendjsons,
+        'table': table,
+        'jsondata': jsondata,
+        'jsoncolors': jsoncolors,
+        'types': ['cascade']*len(figjsons)
+    }
     print('Cascade plot succeeded with %s plots and %s legends and %s table' % (len(figjsons), len(legendjsons), bool(table)))
     return output, figs, legends
 
 
-def get_json_cascade(results,data):
+def get_json_cascade(results, data):
     '''
     Return all data to render cascade in FE, for multiple results
    
@@ -1646,7 +1656,7 @@ def get_json_cascade(results,data):
     jsondata = sc.sanitizejson(cascade_data)
     ncolors = len(result.pop_names)
     jsoncolors = sc.gridcolors(ncolors, ashex=True)
-    return jsondata,jsoncolors
+    return jsondata, jsoncolors
 
 
 @RPC()  

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1271,6 +1271,9 @@ def get_supported_plots(project_id, calibration_page=False, only_keys=False):
         for plot_name, plot_group, val in zip(plot_names, plot_groups, vals):  # Pull out the framework plots.
             this = {'plot_name': plot_name, 'plot_group': plot_group, 'active': val}
             output['plots'].append(this)
+        for plot_name in proj.framework.cascades.keys():
+            this = {'plot_name': plot_name, 'plot_group': 'Cascades', 'active': 1}
+            output['plots'].append(this)
         for plot_group in np.unique(np.array(plot_groups)):
             this = {'group_name': plot_group, 'active': 1}
             output['plotgroups'].append(this)

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1385,6 +1385,9 @@ def make_plots(proj, results, tool=None, year=None, pops=None, cascade=None, plo
     all_figs = []
     all_legends = []
 
+    showbudgetplots = False
+    showcoverageplots = False
+    showcascadeplots = False
     for item in plot_options['plotgroups']:
         if item['group_name'] == 'Program spending plots':
             showbudgetplots = item['active']

--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1364,7 +1364,7 @@ def get_atomica_plots(proj, results=None, plot_names=None, plot_options=None, po
     return output, allfigs, alllegends
 
 
-def make_plots(proj, results, tool=None, year=None, pops=None, cascade=None, plot_options=None, dosave=True, calibration=False, plot_budget=False, outputfigs=False):
+def make_plots(proj, results, tool=None, year=None, pops=None, plot_options=None, dosave=True, calibration=False, plot_budget=False, outputfigs=False):
     
     # Handle inputs
     if sc.isstring(year):
@@ -1399,7 +1399,7 @@ def make_plots(proj, results, tool=None, year=None, pops=None, cascade=None, plo
         if item['group_name'] == 'Cascades':
             showcascadeplots = item['active']
 
-    def append_plots(d,figs,legends):
+    def append_plots(d, figs, legends):
         nonlocal all_figs, all_legends
         all_figs += figs
         all_legends += legends
@@ -1408,8 +1408,8 @@ def make_plots(proj, results, tool=None, year=None, pops=None, cascade=None, plo
         output['types'] += d['types']
 
     if showcascadeplots:
-        cascadeoutput, cascadefigs, cascadelegends = get_cascade_plots(proj, results, year=year, pops=pops, cascade=cascade, plot_budget=plot_budget)
-        append_plots(cascadeoutput,cascadefigs,cascadelegends)
+        cascadeoutput, cascadefigs, cascadelegends = get_cascade_plots(proj, results, year=year, pops=pops, plot_budget=plot_budget)
+        append_plots(cascadeoutput, cascadefigs, cascadelegends)
 
     if calibration:
         d, figs, legends = get_atomica_plots(proj, results=results, pops=pops, plot_options=plot_options, stacked=False, calibration=True)
@@ -1548,7 +1548,7 @@ def get_coverage_plots(results):
     return output, figs, legends
 
 
-def get_cascade_plots(proj, results=None, pops=None, year=None, cascade=None, plot_budget=False):
+def get_cascade_plots(proj, results=None, pops=None, year=None, plot_budget=False):
     
     if results is None:
         results = proj.results[-1]
@@ -1563,8 +1563,8 @@ def get_cascade_plots(proj, results=None, pops=None, year=None, cascade=None, pl
     for y in range(len(years)):
         years[y] = float(years[y]) # Ensure it's a float
 
-    for thecascade in proj.framework.cascades.keys():
-        fig, table = at.plot_cascade(results, cascade=thecascade, pops=pops, year=years, data=proj.data, show_table=False)
+    for cascade in proj.framework.cascades.keys():
+        fig, table = at.plot_cascade(results, cascade=cascade, pops=pops, year=years, data=proj.data, show_table=False)
         figjsons.append(customize_fig(fig=fig, output=None, plotdata=None, xlims=None, figsize=None, is_epi=False))
         figs.append(fig)
         legends.append(sc.emptyfig()) # No figure, but still useful to have a plot
@@ -1663,23 +1663,23 @@ def get_json_cascade(results, data):
 
 
 @RPC()  
-def manual_calibration(project_id, cache_id, parsetname=-1, plot_options=None, plotyear=None, pops=None, tool=None, cascade=None, dosave=True):
+def manual_calibration(project_id, cache_id, parsetname=-1, plot_options=None, plotyear=None, pops=None, tool=None, dosave=True):
     print('Running "manual calibration"...')
     proj = load_project(project_id, die=True)
     result = proj.run_sim(parset=parsetname, store_results=False)
     cache_result(proj, result, cache_id)
-    output = make_plots(proj, result, tool=tool, year=plotyear, pops=pops, cascade=cascade, plot_options=plot_options, dosave=dosave, calibration=True)
+    output = make_plots(proj, result, tool=tool, year=plotyear, pops=pops, plot_options=plot_options, dosave=dosave, calibration=True)
     return output
 
 
 @RPC()    
-def automatic_calibration(project_id, cache_id, parsetname=-1, max_time=20, saveresults=True, plot_options=None, tool=None, plotyear=None, pops=None,cascade=None, dosave=True):
+def automatic_calibration(project_id, cache_id, parsetname=-1, max_time=20, saveresults=True, plot_options=None, tool=None, plotyear=None, pops=None, dosave=True):
     print('Running automatic calibration for parset %s...' % parsetname)
     proj = load_project(project_id, die=True)
     proj.calibrate(parset=parsetname, max_time=float(max_time)) # WARNING, add kwargs!
     result = proj.run_sim(parset=parsetname, store_results=False)
     cache_result(proj, result, cache_id)
-    output = make_plots(proj, result, tool=tool, year=plotyear, pops=pops, cascade=cascade, plot_options=plot_options, dosave=dosave, calibration=True)
+    output = make_plots(proj, result, tool=tool, year=plotyear, pops=pops, plot_options=plot_options, dosave=dosave, calibration=True)
     return output
 
 
@@ -2133,14 +2133,14 @@ def scen_reset_values(js_scen, project_id):
 
 
 @RPC()    
-def run_scenarios(project_id, cache_id, plot_options, saveresults=True, tool=None, plotyear=None, pops=None,cascade=None, dosave=True):
+def run_scenarios(project_id, cache_id, plot_options, saveresults=True, tool=None, plotyear=None, pops=None, dosave=True):
     print('Running scenarios...')
     proj = load_project(project_id, die=True)
     results = proj.run_scenarios(store_results=False)
     if len(results) < 1:  # Fail if we have no results (user didn't pick a scenario)
         return {'error': 'No scenario selected'}
     cache_result(proj, results, cache_id)
-    output = make_plots(proj, results, tool=tool, year=plotyear, pops=pops, cascade=cascade, plot_options=plot_options, dosave=dosave, calibration=False, plot_budget=True)
+    output = make_plots(proj, results, tool=tool, year=plotyear, pops=pops, plot_options=plot_options, dosave=dosave, calibration=False, plot_budget=True)
     print('Saving project...')
     save_project(proj)
     return output
@@ -2217,15 +2217,15 @@ def set_optim_info(project_id, optim_jsons, verbose=False):
 
 # This is the function we should use on occasions when we can't use Celery.
 @RPC()
-def run_optimization(project_id, cache_id, optim_name=None, plot_options=None, maxtime=None, tool=None, plotyear=None, pops=None, cascade=None, dosave=True):
+def run_optimization(project_id, cache_id, optim_name=None, plot_options=None, maxtime=None, tool=None, plotyear=None, pops=None, dosave=True):
     print('Running Cascade optimization...')
-    sc.printvars(locals(), ['project_id', 'optim_name', 'plot_options', 'maxtime', 'tool', 'plotyear', 'pops', 'cascade', 'dosave'], color='blue')
+    sc.printvars(locals(), ['project_id', 'optim_name', 'plot_options', 'maxtime', 'tool', 'plotyear', 'pops', 'dosave'], color='blue')
     proj = load_project(project_id, die=True)
         
     # Actually run the optimization and get its results (list of baseline and optimized Result objects).
     results = proj.run_optimization(optim_name, maxtime=float(maxtime), store_results=False)
     cache_result(proj, results, cache_id)
-    output = make_plots(proj, results, tool=tool, year=plotyear, pops=pops, cascade=cascade, plot_options=plot_options, dosave=dosave, plot_budget=True) # Plot the results.   
+    output = make_plots(proj, results, tool=tool, year=plotyear, pops=pops, plot_options=plot_options, dosave=dosave, plot_budget=True) # Plot the results.
     save_project(proj)
     return output
 
@@ -2281,13 +2281,13 @@ def clear_cached_results(proj, project_id, spare_calibration=False, verbose=True
 
 
 @RPC() 
-def plot_results(project_id, cache_id, plot_options, tool=None, plotyear=None, pops=None, cascade=None, dosave=True, plotbudget=False, calibration=False):
+def plot_results(project_id, cache_id, plot_options, tool=None, plotyear=None, pops=None, dosave=True, plotbudget=False, calibration=False):
     print('Plotting cached results...')
     proj = load_project(project_id, die=True)
     results = load_result(cache_id) # Load the results from the cache and check if we got a result.
     if results is None:
         return { 'error': 'Failed to load plot results from cache' }
-    output = make_plots(proj, results, tool=tool, year=plotyear, pops=pops, cascade=cascade, plot_options=plot_options, dosave=dosave, plot_budget=plotbudget, calibration=calibration)
+    output = make_plots(proj, results, tool=tool, year=plotyear, pops=pops, plot_options=plot_options, dosave=dosave, plot_budget=plotbudget, calibration=calibration)
     return output
     
 

--- a/src/cascade/app/CalibrationPage.vue
+++ b/src/cascade/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-23
+Last update: 2019-06-03
 -->
 
 <template>
@@ -109,16 +109,6 @@ Last update: 2019-05-23
           <!-- ### Start: plot controls ### -->
           <div class="calib-title"><help reflink="bl-results" label="Results"></help></div>
               <div class="controls-box">
-
-              <template v-if="simCascades.length>1">
-                <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(true)">
-                  <option v-for='cascade in simCascades'>
-                    {{ cascade }}
-                  </option>
-                </select>
-              </template>
-
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in simYears'>
@@ -189,22 +179,24 @@ Last update: 2019-05-23
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="(item, index) in plotOptions.plotgroups">
                   <thead>
                   <tr>
-                    <th>Plot</th>
-                    <th>Active</th>
+                    <th>
+                      <span @click="plotGroupListCollapseToggle(index)">
+                      {{ item.group_name }}
+                      </span>
+                      &nbsp;&nbsp;
+                      <input type="checkbox" @click="plotGroupActiveToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                    </th>
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions">
-                    <td>
-                      {{ item.plot_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" v-model="item.active"/>
-                    </td>
-                  </tr>
+                    <tr v-if="!plotGroupsListCollapsed[index]" v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                      <td>
+                        {{ name }}
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/src/cascade/app/OptimizationsPage.vue
+++ b/src/cascade/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-23
+Last update: 2019-06-03
 -->
 
 <template>
@@ -74,16 +74,6 @@ Last update: 2019-05-23
           <div class="calib-title">
             <help reflink="results-plots" label="Results"></help>
             <div>
-
-              <template v-if="simCascades.length>1">
-                <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(displayResultDatastoreId, true)">
-                  <option v-for='cascade in simCascades'>
-                    {{ cascade }}
-                  </option>
-                </select>
-              </template>
-
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(displayResultDatastoreId, true)">
                 <option v-for='year in projectionYears'>
@@ -175,22 +165,24 @@ Last update: 2019-05-23
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="(item, index) in plotOptions.plotgroups">
                   <thead>
                   <tr>
-                    <th>Plot</th>
-                    <th>Active</th>
+                    <th>
+                      <span @click="plotGroupListCollapseToggle(index)">
+                      {{ item.group_name }}
+                      </span>
+                      &nbsp;&nbsp;
+                      <input type="checkbox" @click="plotGroupActiveToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                    </th>
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions">
-                    <td>
-                      {{ item.plot_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" v-model="item.active"/>
-                    </td>
-                  </tr>
+                    <tr v-if="!plotGroupsListCollapsed[index]" v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                      <td>
+                        {{ name }}
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/src/cascade/app/ScenariosPage.vue
+++ b/src/cascade/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-23
+Last update: 2019-06-03
 -->
 
 <template>
@@ -70,16 +70,6 @@ Last update: 2019-05-23
           <div class="calib-title">
             <help reflink="results-plots" label="Results"></help>
             <div>
-
-              <template v-if="simCascades.length>1">
-                <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(true)">
-                  <option v-for='cascade in simCascades'>
-                    {{ cascade }}
-                  </option>
-                </select>
-              </template>
-
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(true)">
                 <option v-for='year in projectionYears'>
@@ -171,22 +161,24 @@ Last update: 2019-05-23
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="(item, index) in plotOptions.plotgroups">
                   <thead>
                   <tr>
-                    <th>Plot</th>
-                    <th>Active</th>
+                    <th>
+                      <span @click="plotGroupListCollapseToggle(index)">
+                      {{ item.group_name }}
+                      </span>
+                      &nbsp;&nbsp;
+                      <input type="checkbox" @click="plotGroupActiveToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                    </th>
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions">
-                    <td>
-                      {{ item.plot_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" v-model="item.active"/>
-                    </td>
-                  </tr>
+                    <tr v-if="!plotGroupsListCollapsed[index]" v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                      <td>
+                        {{ name }}
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -19,6 +19,7 @@ var CalibrationMixin = {
         activeCascade: "",
         popOptions: [],
         plotOptions: [],
+        plotGroupsListCollapsed: [],
         yearOptions: [],
         serverDatastoreId: '',
         openDialogs: [],
@@ -138,7 +139,34 @@ var CalibrationMixin = {
       minimize(legend_id) { 
         return this.$sciris.minimize(this, legend_id) 
       },
-
+      
+      plotGroupActiveToggle(groupname, active) {
+        console.log('plotGroupActiveToggle() called for plot group: ', groupname, ' changing from: ', active)
+        for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
+          if (this.plotOptions.plots[ind].plot_group == groupname) {
+            this.plotOptions.plots[ind].active = !active
+          }
+        }
+      },
+    
+      plotGroupListCollapseToggle(index) {
+        console.log('plotGroupListCollapseToggle() called for plot index: ', index)
+        this.plotGroupsListCollapsed[index] = !this.plotGroupsListCollapsed[index]
+        // Stupid hack required to update Vue with this data...
+        this.plotGroupsListCollapsed.push(false)
+        this.plotGroupsListCollapsed.pop()
+      },
+      
+      getPlotsFromPlotGroup(groupname) {
+        let members = []
+        for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
+          if (this.plotOptions.plots[ind].plot_group == groupname) {
+            members.push(this.plotOptions.plots[ind].plot_name)
+          }
+        }
+        return members      
+      },
+    
       toggleParams() {
         this.showParameters = !this.showParameters
       },

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -47,7 +47,6 @@ var CalibrationMixin = {
       simStart()     { return utils.simStart(this) },
       simEnd()       { return utils.simEnd(this) },
       simYears()     { return utils.simYears(this) },
-      simCascades()  { return utils.simCascades(this) },
       activePops()   { return utils.activePops(this) },
 
       filteredParlist() {
@@ -323,7 +322,6 @@ var CalibrationMixin = {
           'plotyear':this.simEndYear, 
           'pops':this.activePop, 
           'tool': this.toolName(), 
-          'cascade':null
         }) // Go to the server to get the results
         .then(response => {
           this.makeGraphs(response.data)
@@ -355,7 +353,6 @@ var CalibrationMixin = {
           'plotyear': this.simEndYear, 
           'pops': this.activePop, 
           'tool': this.toolName(), 
-          'cascade':null
         }) // Go to the server to get the results from the package set.
         .then(response => {
           this.table = response.data.table

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -16,7 +16,6 @@ var CalibrationMixin = {
         simStartYear: 0,
         simEndYear: 2018, // TEMP FOR DEMO
         activePop: "All",
-        activeCascade: "",
         popOptions: [],
         plotOptions: [],
         plotGroupsListCollapsed: [],
@@ -65,7 +64,6 @@ var CalibrationMixin = {
         this.simStartYear = this.simStart
         this.simEndYear = this.simEnd
         this.popOptions = this.activePops
-        this.activeCascade = this.simCascades[0]
         this.serverDatastoreId = this.$store.state.activeProject.project.id + ':calibration'
         this.getPlotOptions(this.$store.state.activeProject.project.id)
           .then(response => {

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -109,7 +109,7 @@ var CalibrationMixin = {
         return utils.togglePlotControls(this) 
       },
       getPlotOptions(project_id) { 
-        return utils.getPlotOptions(this, project_id) 
+        return utils.getPlotOptions(this, project_id, true) 
       },
 /*      makeGraphs(graphdata) { 
         return this.$sciris.makeGraphs(this, graphdata, '/calibration') 

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -16,7 +16,6 @@ var OptimizationMixin = {
       simStartYear: 0,
       simEndYear: 2018, // TEMP FOR DEMO
       activePop: "All",
-      activeCascade: "",
       popOptions: [],
       plotOptions: [],
       plotGroupsListCollapsed: [],
@@ -64,7 +63,6 @@ var OptimizationMixin = {
       this.simStartYear = this.simStart
       this.simEndYear = this.simEnd
       this.popOptions = this.activePops
-      this.activeCascade = this.simCascades[0]
       this.getPlotOptions(this.$store.state.activeProject.project.id)
         .then(response => {
           this.updateSets()

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -48,7 +48,6 @@ var OptimizationMixin = {
     hasPrograms()  { return utils.hasPrograms(this) },
     simStart()     { return utils.simStart(this) },
     simEnd()       { return utils.simEnd(this) },
-    simCascades()  { return utils.simCascades(this) },
     projectionYears()     { return utils.projectionYears(this) },
     activePops()   { return utils.activePops(this) },
   },
@@ -493,7 +492,6 @@ var OptimizationMixin = {
                 'tool': this.toolName(), 
                 'plotyear': this.simEndYear, 
                 'pops': this.activePop, 
-                'cascade': null
               }
             ])  // should this last be null?
             .then(response => {

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -83,7 +83,7 @@ var OptimizationMixin = {
     scaleFigs(frac)                   { return this.$sciris.scaleFigs(this, frac)},
     clearGraphs()                     { return this.$sciris.clearGraphs(this) },
     togglePlotControls()              { return utils.togglePlotControls(this) },
-    getPlotOptions(project_id)        { return utils.getPlotOptions(this, project_id) },
+    getPlotOptions(project_id)        { return utils.getPlotOptions(this, project_id, false) },
 /*    makeGraphs(graphdata)             { return this.$sciris.makeGraphs(this, graphdata, '/optimizations') }, */
     makeGraphs(graphdata)             { return utils.makeGraphs(this, graphdata, '/optimizations') },reloadGraphs(cache_id, showErr)   { 
       // Make sure the start end years are in the right range.

--- a/src/common/mixins/optimization.js
+++ b/src/common/mixins/optimization.js
@@ -19,6 +19,7 @@ var OptimizationMixin = {
       activeCascade: "",
       popOptions: [],
       plotOptions: [],
+      plotGroupsListCollapsed: [],
       yearOptions: [],
       serverDatastoreId: '',
       openDialogs: [],
@@ -97,7 +98,34 @@ var OptimizationMixin = {
     }, 
     maximize(legend_id)               { return this.$sciris.maximize(this, legend_id) },
     minimize(legend_id)               { return this.$sciris.minimize(this, legend_id) },
-
+    
+    plotGroupActiveToggle(groupname, active) {
+      console.log('plotGroupActiveToggle() called for plot group: ', groupname, ' changing from: ', active)
+      for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
+        if (this.plotOptions.plots[ind].plot_group == groupname) {
+          this.plotOptions.plots[ind].active = !active
+        }
+      }
+    },
+    
+    plotGroupListCollapseToggle(index) {
+      console.log('plotGroupListCollapseToggle() called for plot index: ', index)
+      this.plotGroupsListCollapsed[index] = !this.plotGroupsListCollapsed[index]
+      // Stupid hack required to update Vue with this data...
+      this.plotGroupsListCollapsed.push(false)
+      this.plotGroupsListCollapsed.pop()
+    },
+    
+    getPlotsFromPlotGroup(groupname) {
+      let members = []
+      for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
+        if (this.plotOptions.plots[ind].plot_group == groupname) {
+          members.push(this.plotOptions.plots[ind].plot_name)
+        }
+      }
+      return members      
+    },
+    
     statusFormatStr(optimSummary) {
       if      (optimSummary.status === 'not started') {return ''}
       else if (optimSummary.status === 'queued')      {return 'Initializing... '} // + this.timeFormatStr(optimSummary.pendingTime)

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -121,6 +121,15 @@ var ScenarioMixin = {
     maximize(legend_id)               { return this.$sciris.maximize(this, legend_id) },
     minimize(legend_id)               { return this.$sciris.minimize(this, legend_id) },
     
+    plotGroupToggle(groupname, active) {
+      console.log('plotGroupToggle() called for plot group: ', groupname, ' changing from: ', active)
+      for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
+        if (this.plotOptions.plots[ind].plot_group == groupname) {
+          this.plotOptions.plots[ind].active = !active
+        }
+      }
+    },
+    
     paramGroupMembers(groupname) { 
       let members = []
       for (var ind = 0; ind < this.paramGroups.codenames.length; ind++) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -17,7 +17,6 @@ var ScenarioMixin = {
       simStartYear: 0,
       simEndYear: 2035,
       activePop: "All",
-      activeCascade: "",
       popOptions: [],
       plotOptions: [],
       plotGroupsListCollapsed: [],
@@ -76,7 +75,6 @@ var ScenarioMixin = {
         this.validSimYears.push(year)
       }      
       this.popOptions = this.activePops
-      this.activeCascade = this.simCascades[0]
       this.serverDatastoreId = this.$store.state.activeProject.project.id + ':scenario'
       this.getPlotOptions(this.$store.state.activeProject.project.id)
         .then(response => {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -100,7 +100,7 @@ var ScenarioMixin = {
     scaleFigs(frac)                   { return this.$sciris.scaleFigs(this, frac)},
     clearGraphs()                     { return this.$sciris.clearGraphs(this) },
     togglePlotControls()              { return utils.togglePlotControls(this) },
-    getPlotOptions(project_id)        { return utils.getPlotOptions(this, project_id) },
+    getPlotOptions(project_id)        { return utils.getPlotOptions(this, project_id, false) },
 /*    makeGraphs(graphdata)             { return this.$sciris.makeGraphs(this, graphdata, '/scenarios') }, */
     makeGraphs(graphdata)             { return utils.makeGraphs(this, graphdata, '/scenarios') },    
     reloadGraphs(showErr)             { 

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -130,6 +130,16 @@ var ScenarioMixin = {
       }
     },
     
+    getPlotsFromPlotGroup(groupname) {
+      let members = []
+      for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
+        if (this.plotOptions.plots[ind].plot_group == groupname) {
+          members.push(this.plotOptions.plots[ind].plot_name)
+        }
+      }
+      return members      
+    },
+    
     paramGroupMembers(groupname) { 
       let members = []
       for (var ind = 0; ind < this.paramGroups.codenames.length; ind++) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -20,6 +20,7 @@ var ScenarioMixin = {
       activeCascade: "",
       popOptions: [],
       plotOptions: [],
+      plotGroupsListCollapsed: [],
       yearOptions: [],
       serverDatastoreId: '',
       openDialogs: [],
@@ -121,13 +122,21 @@ var ScenarioMixin = {
     maximize(legend_id)               { return this.$sciris.maximize(this, legend_id) },
     minimize(legend_id)               { return this.$sciris.minimize(this, legend_id) },
     
-    plotGroupToggle(groupname, active) {
-      console.log('plotGroupToggle() called for plot group: ', groupname, ' changing from: ', active)
+    plotGroupActiveToggle(groupname, active) {
+      console.log('plotGroupActiveToggle() called for plot group: ', groupname, ' changing from: ', active)
       for (var ind = 0; ind < this.plotOptions.plots.length; ind++) {
         if (this.plotOptions.plots[ind].plot_group == groupname) {
           this.plotOptions.plots[ind].active = !active
         }
       }
+    },
+    
+    plotGroupListCollapseToggle(index) {
+      console.log('plotGroupListCollapseToggle() called for plot index: ', index)
+      this.plotGroupsListCollapsed[index] = !this.plotGroupsListCollapsed[index]
+      // Stupid hack required to update Vue with this data...
+      this.plotGroupsListCollapsed.push(false)
+      this.plotGroupsListCollapsed.pop()
     },
     
     getPlotsFromPlotGroup(groupname) {

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -53,7 +53,6 @@ var ScenarioMixin = {
     hasPrograms()  { return utils.hasPrograms(this) },
     simStart()     { return utils.simStart(this) },
     simEnd()       { return utils.simEnd(this) },
-    simCascades()  { return utils.simCascades(this) },
     projectionYears()     { return utils.projectionYears(this) },
     activePops()   { return utils.activePops(this) },
     sortedParamOverwrites() {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -282,8 +282,7 @@ function reloadGraphs(vm, project_id, cache_id, showNoCacheError, iscalibration,
     cache_id, 
     vm.plotOptions
   ], {
-    tool: vm.toolName(), 
-    cascade: vm.activeCascade,
+    tool: vm.toolName(),
     plotyear: vm.simEndYear,
     pops: vm.activePop, 
     calibration: iscalibration, 

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -256,6 +256,10 @@ function getPlotOptions(vm, project_id, calibration_page) {
     sciris.rpcs.rpc('get_supported_plots', [project_id, calibration_page, true])
       .then(response => {
         vm.plotOptions = response.data // Get the parameter values
+        vm.plotGroupsListCollapsed = []
+        for (var ind = 0; ind < vm.plotOptions.plotgroups.length; ind++) {
+          vm.plotGroupsListCollapsed.push(true)
+        }
         sciris.status.succeed(vm, '')
         resolve(response)
       })

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -249,11 +249,11 @@ function updateDatasets(vm) {
   })
 }
 
-function getPlotOptions(vm, project_id) {
+function getPlotOptions(vm, project_id, calibration_page) {
   return new Promise((resolve, reject) => {
     console.log('getPlotOptions() called')
     sciris.status.start(vm) // Start indicating progress.
-    sciris.rpcs.rpc('get_supported_plots', [project_id, true])
+    sciris.rpcs.rpc('get_supported_plots', [project_id, calibration_page, true])
       .then(response => {
         vm.plotOptions = response.data // Get the parameter values
         sciris.status.succeed(vm, '')

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-30
+Last update: 2019-06-01
 -->
 
 <template>
@@ -195,22 +195,24 @@ Last update: 2019-05-30
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="(item, index) in plotOptions.plotgroups">
                   <thead>
                   <tr>
-                    <th>Plot</th>
-                    <th>Active</th>
+                    <th>
+                      <span @click="plotGroupListCollapseToggle(index)">
+                      {{ item.group_name }}
+                      </span>
+                      &nbsp;&nbsp;
+                      <input type="checkbox" @click="plotGroupActiveToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                    </th>
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions.plots">
-                    <td>
-                      {{ item.plot_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" v-model="item.active"/>
-                    </td>
-                  </tr>
+                    <tr v-if="!plotGroupsListCollapsed[index]" v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                      <td>
+                        {{ name }}
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-06-01
+Last update: 2019-06-03
 -->
 
 <template>
@@ -118,14 +118,6 @@ Last update: 2019-06-01
           <div class="calib-title">
             <help reflink="bl-results" label="Results"></help>
             <div>
-              <template v-if="simCascades.length>1">
-                <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(true)">
-                  <option v-for='cascade in simCascades'>
-                    {{ cascade }}
-                  </option>
-                </select>
-              </template>
               &nbsp;&nbsp;&nbsp;
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(true)">

--- a/src/tb/app/CalibrationPage.vue
+++ b/src/tb/app/CalibrationPage.vue
@@ -1,7 +1,7 @@
 <!--
 Calibration Page
 
-Last update: 2019-05-23
+Last update: 2019-05-30
 -->
 
 <template>
@@ -203,7 +203,7 @@ Last update: 2019-05-23
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions">
+                  <tr v-for="item in plotOptions.plots">
                     <td>
                       {{ item.plot_name }}
                     </td>

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-06-01
+Last update: 2019-06-03
 -->
 
 <template>
@@ -75,14 +75,6 @@ Last update: 2019-06-01
           <div class="calib-title">
             <help reflink="results-plots" label="Results"></help>
             <div>
-              <template v-if="simCascades.length>1">
-                <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(displayResultDatastoreId, true)">
-                  <option v-for='cascade in simCascades'>
-                    {{ cascade }}
-                  </option>
-                </select>
-              </template>
               &nbsp;&nbsp;&nbsp;
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(displayResultDatastoreId, true)">

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-23
+Last update: 2019-05-30
 -->
 
 <template>
@@ -162,7 +162,7 @@ Last update: 2019-05-23
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions">
+                  <tr v-for="item in plotOptions.plots">
                     <td>
                       {{ item.plot_name }}
                     </td>

--- a/src/tb/app/OptimizationsPage.vue
+++ b/src/tb/app/OptimizationsPage.vue
@@ -1,7 +1,7 @@
 <!--
 Optimizations Page
 
-Last update: 2019-05-30
+Last update: 2019-06-01
 -->
 
 <template>
@@ -154,22 +154,24 @@ Last update: 2019-05-30
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="(item, index) in plotOptions.plotgroups">
                   <thead>
                   <tr>
-                    <th>Plot</th>
-                    <th>Active</th>
+                    <th>
+                      <span @click="plotGroupListCollapseToggle(index)">
+                      {{ item.group_name }}
+                      </span>
+                      &nbsp;&nbsp;
+                      <input type="checkbox" @click="plotGroupActiveToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                    </th>
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions.plots">
-                    <td>
-                      {{ item.plot_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" v-model="item.active"/>
-                    </td>
-                  </tr>
+                    <tr v-if="!plotGroupsListCollapsed[index]" v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                      <td>
+                        {{ name }}
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-23
+Last update: 2019-05-30
 -->
 
 <template>
@@ -163,7 +163,7 @@ Last update: 2019-05-23
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions">
+                  <tr v-for="item in plotOptions.plots">
                     <td>
                       {{ item.plot_name }}
                     </td>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -155,51 +155,26 @@ Last update: 2019-05-31
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="item in plotOptions.plotgroups">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="(item, index) in plotOptions.plotgroups">
                   <thead>
                   <tr>
                     <th>
+                      <span @click="plotGroupListCollapseToggle(index)">
                       {{ item.group_name }}
+                      </span>
                       &nbsp;&nbsp;
-                      <input type="checkbox" @click="plotGroupToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                      <input type="checkbox" @click="plotGroupActiveToggle(item.group_name, item.active)" v-model="item.active"/>                    
                     </th>
                   </tr>
                   </thead>
                   <tbody>
-                    <tr v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                    <tr v-if="!plotGroupsListCollapsed[index]" v-for="name in getPlotsFromPlotGroup(item.group_name)">
                       <td>
                         {{ name }}
                       </td>
                     </tr>
-<!--                  <tr v-for="item in plotOptions.plotgroups">
-                    <td>
-                      {{ item.group_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" @click="plotGroupToggle(item.group_name, item.active)" v-model="item.active"/>
-                    </td>
-                  </tr> -->
                   </tbody>
                 </table>
-                
-<!--                <table class="table table-bordered table-hover table-striped" style="width: 100%">
-                  <thead>
-                  <tr>
-                    <th>Plot group</th>
-                    <th>Active</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr v-for="item in plotOptions.plotgroups">
-                    <td>
-                      {{ item.group_name }}
-                    </td>
-                    <td style="text-align: center">
-                      <input type="checkbox" @click="plotGroupToggle(item.group_name, item.active)" v-model="item.active"/>
-                    </td>
-                  </tr>
-                  </tbody>
-                </table> -->
               </div>
             </div>
             <!-- ### End: plot selectors ### -->

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-31
+Last update: 2019-06-03
 -->
 
 <template>
@@ -76,14 +76,6 @@ Last update: 2019-05-31
           <div class="calib-title">
             <help reflink="results-plots" label="Results"></help>
             <div>
-              <template v-if="simCascades.length>1">
-                <b>Cascade: &nbsp;</b>
-                <select v-model="activeCascade" @change="reloadGraphs(true)">
-                  <option v-for='cascade in simCascades'>
-                    {{ cascade }}
-                  </option>
-                </select>
-              </template>
               &nbsp;&nbsp;&nbsp;
               <b>Year: &nbsp;</b>
               <select v-model="simEndYear" @change="reloadGraphs(true)">

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -168,7 +168,7 @@ Last update: 2019-05-30
                       {{ item.group_name }}
                     </td>
                     <td style="text-align: center">
-                      <input type="checkbox" v-model="item.active"/>
+                      <input type="checkbox" @click="plotGroupToggle(item.group_name, item.active)" v-model="item.active"/>
                     </td>
                   </tr>
                   </tbody>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -158,14 +158,14 @@ Last update: 2019-05-30
                 <table class="table table-bordered table-hover table-striped" style="width: 100%">
                   <thead>
                   <tr>
-                    <th>Plot</th>
+                    <th>Plot group</th>
                     <th>Active</th>
                   </tr>
                   </thead>
                   <tbody>
-                  <tr v-for="item in plotOptions.plots">
+                  <tr v-for="item in plotOptions.plotgroups">
                     <td>
-                      {{ item.plot_name }}
+                      {{ item.group_name }}
                     </td>
                     <td style="text-align: center">
                       <input type="checkbox" v-model="item.active"/>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-05-30
+Last update: 2019-05-31
 -->
 
 <template>
@@ -155,7 +155,34 @@ Last update: 2019-05-30
             <!-- ### Start: plot selectors ### -->
             <div class="plotopts-main" :class="{'plotopts-main--full': !showPlotControls}" v-if="showPlotControls">
               <div class="plotopts-params">
-                <table class="table table-bordered table-hover table-striped" style="width: 100%">
+                <table class="table table-bordered table-hover table-striped" style="width: 100%" v-for="item in plotOptions.plotgroups">
+                  <thead>
+                  <tr>
+                    <th>
+                      {{ item.group_name }}
+                      &nbsp;&nbsp;
+                      <input type="checkbox" @click="plotGroupToggle(item.group_name, item.active)" v-model="item.active"/>                    
+                    </th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="name in getPlotsFromPlotGroup(item.group_name)">
+                      <td>
+                        {{ name }}
+                      </td>
+                    </tr>
+<!--                  <tr v-for="item in plotOptions.plotgroups">
+                    <td>
+                      {{ item.group_name }}
+                    </td>
+                    <td style="text-align: center">
+                      <input type="checkbox" @click="plotGroupToggle(item.group_name, item.active)" v-model="item.active"/>
+                    </td>
+                  </tr> -->
+                  </tbody>
+                </table>
+                
+<!--                <table class="table table-bordered table-hover table-striped" style="width: 100%">
                   <thead>
                   <tr>
                     <th>Plot group</th>
@@ -172,7 +199,7 @@ Last update: 2019-05-30
                     </td>
                   </tr>
                   </tbody>
-                </table>
+                </table> -->
               </div>
             </div>
             <!-- ### End: plot selectors ### -->


### PR DESCRIPTION
This PR changes the plot selection pane (for both the TB and Cascade sites) so that plot groups are selected / deselected instead of individual graphs.  The individual graphs (except for the budget and coverage graphs) can be viewed by clicking on the plot group labels to toggle lists in the tables.  Multiple cascade plots are also allowed now, and the cascade dropdown lists have been removed.