### PR TITLE
Fix calibration page plots

### DIFF
--- a/atomica_apps/rpcs.py
+++ b/atomica_apps/rpcs.py
@@ -1472,9 +1472,9 @@ def make_plots(proj, results, tool=None, year=None, pops=None, plot_options=None
         if item['group_name'] == 'TB calibration':
             show_tb_calibration = item['active']
         if item['group_name'] == 'TB probabilistic cascades':
-            show_tb_advanced = item['active']
-        if item['group_name'] == 'TB advanced':
             show_tb_cascade = item['active']
+        if item['group_name'] == 'TB advanced':
+            show_tb_advanced = item['active']
 
     def append_plots(d, figs, legends):
         nonlocal all_figs, all_legends

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -62,7 +62,7 @@ var CalibrationMixin = {
         (this.$store.state.activeProject.project.hasData) ) {
         console.log('created() called')
         this.simStartYear = this.simStart
-        this.simEndYear = this.simEnd  // this.dataEnd
+        this.simEndYear = this.dataEnd
         this.popOptions = this.activePops
         this.serverDatastoreId = this.$store.state.activeProject.project.id + ':calibration'
         this.getPlotOptions(this.$store.state.activeProject.project.id)

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -47,7 +47,7 @@ var CalibrationMixin = {
       simStart()     { return utils.simStart(this) },
       simEnd()       { return utils.simEnd(this) },
       simYears()     { return utils.simYears(this) },
-      simEnd()       { return utils.simEnd(this) },
+      activePops()   { return utils.activePops(this) },
       dataEnd()      { return utils.dataEnd(this) },
 
       filteredParlist() {

--- a/src/common/mixins/calibration.js
+++ b/src/common/mixins/calibration.js
@@ -47,7 +47,8 @@ var CalibrationMixin = {
       simStart()     { return utils.simStart(this) },
       simEnd()       { return utils.simEnd(this) },
       simYears()     { return utils.simYears(this) },
-      activePops()   { return utils.activePops(this) },
+      simEnd()       { return utils.simEnd(this) },
+      dataEnd()      { return utils.dataEnd(this) },
 
       filteredParlist() {
         return this.applyParametersFilter(this.parlist)
@@ -61,7 +62,7 @@ var CalibrationMixin = {
         (this.$store.state.activeProject.project.hasData) ) {
         console.log('created() called')
         this.simStartYear = this.simStart
-        this.simEndYear = this.simEnd
+        this.simEndYear = this.simEnd  // this.dataEnd
         this.popOptions = this.activePops
         this.serverDatastoreId = this.$store.state.activeProject.project.id + ':calibration'
         this.getPlotOptions(this.$store.state.activeProject.project.id)

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -494,7 +494,8 @@ function makeGraphs(vm, data, routepath) {
           // Draw the mpld3 figure into the figN div where it belongs.
           try {
             // If we are dealing with a cascade or budget figure... 
-            if (graphtypes[index] == "cascade" || graphtypes[index] == "budget") {
+            if (graphtypes[index] == "cascade" || graphtypes[index] == "budget" || 
+              graphtypes[index] == "tb-cascade") {
               sciris.graphs.mpld3.draw_figure(figlabel, graphdata[index], function (fig, element) {
                 fig.axes[0].axisList[0].props.tickformat_formatter = "fixed"         
               }, true)

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -240,7 +240,7 @@ Last update: 2019-06-03
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
             <b>Parameters</b><br>
-            <select v-model="addEditModal.selectedParams" size="4" multiple>
+            <select v-model="addEditModal.selectedParams" size="5" multiple>
               <option v-for="paramname in paramGroupMembers(addEditModal.selectedParamGroup)">
                 {{ paramname }}
               </option>
@@ -250,7 +250,7 @@ Last update: 2019-06-03
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
             <b>Populations</b><br>
-            <select v-model="addEditModal.selectedPopulations" size="4" multiple>
+            <select v-model="addEditModal.selectedPopulations" size="5" multiple>
               <option v-for="popname in paramGroups.popnames">
                 {{ popname }}
               </option>

--- a/src/tb/app/ScenariosPage.vue
+++ b/src/tb/app/ScenariosPage.vue
@@ -1,7 +1,7 @@
 <!--
 Scenarios page
 
-Last update: 2019-06-03
+Last update: 2019-06-04
 -->
 
 <template>
@@ -240,7 +240,7 @@ Last update: 2019-06-03
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
             <b>Parameters</b><br>
-            <select v-model="addEditModal.selectedParams" size="5" multiple>
+            <select v-model="addEditModal.selectedParams" :size="paramGroupMembers(addEditModal.selectedParamGroup).length" multiple>
               <option v-for="paramname in paramGroupMembers(addEditModal.selectedParamGroup)">
                 {{ paramname }}
               </option>
@@ -250,7 +250,7 @@ Last update: 2019-06-03
           <div v-if="addEditModal.scenSummary.scentype == 'parameter'"
                style="display:inline-block; padding-right:10px">
             <b>Populations</b><br>
-            <select v-model="addEditModal.selectedPopulations" size="5" multiple>
+            <select v-model="addEditModal.selectedPopulations" :size="paramGroups.popnames.length" multiple>
               <option v-for="popname in paramGroups.popnames">
                 {{ popname }}
               </option>


### PR DESCRIPTION
This PR (so far) makes a couple of changes:
* The default setting of the Calibration page dropdown Year is made `dataEnd` instead of `simEnd`.
* The dropdowns for the Parameters and Populations in the creation of parameter scenarios resize to fit the number of options to choose from.