### PR TITLE
Post demo fixes1 gc

### DIFF
--- a/src/common/mixins/project.js
+++ b/src/common/mixins/project.js
@@ -108,22 +108,24 @@ var ProjectMixin = {
       this.$sciris.start(this)
       this.$sciris.rpc('jsonify_projects', [this.userName]) // Get the current user's project summaries from the server.
         .then(response => {
-          let lastCreationTime = null
+          let lastCreationTimeDate = null
+          let creationTimeDate = null
           let lastCreatedID = null
           this.projectSummaries = response.data.projects // Set the projects to what we received.
           if (this.projectSummaries.length > 0) { // Initialize the last creation time stuff if we have a non-empty list.
-            lastCreationTime = new Date(this.projectSummaries[0].project.creationTime)
+            lastCreationTimeDate = new Date(this.projectSummaries[0].project.creationTime)
             lastCreatedID = this.projectSummaries[0].project.id
           }
           this.projectToRename = null  // Unset the link to a project being renamed.
           this.projectSummaries.forEach(theProj => { // Preprocess all projects.
             theProj.selected = false // Set to not selected.
             theProj.renaming = '' // Set to not being renamed.
-            if (theProj.project.creationTime >= lastCreationTime) { // Update the last creation time and ID if what se see is later.
-              lastCreationTime = theProj.project.creationTime
+            creationTimeDate = new Date(theProj.project.creationTime)          
+            if (creationTimeDate >= lastCreationTimeDate) { // Update the last creation time and ID if what se see is later.
+              lastCreationTimeDate = creationTimeDate
               lastCreatedID = theProj.project.id
             }
-          })
+          })          
           if (this.projectSummaries.length > 0) { // If we have a project on the list...
             if (setActiveID === null) { // If no ID is passed in, set the active project to the last-created project.
               this.openProject(lastCreatedID)

--- a/src/common/mixins/project.js
+++ b/src/common/mixins/project.js
@@ -121,7 +121,7 @@ var ProjectMixin = {
             theProj.selected = false // Set to not selected.
             theProj.renaming = '' // Set to not being renamed.
             creationTimeDate = new Date(theProj.project.creationTime)          
-            if (creationTimeDate >= lastCreationTimeDate) { // Update the last creation time and ID if what se see is later.
+            if (creationTimeDate >= lastCreationTimeDate) { // Update the last creation time and ID if what we see is later.
               lastCreationTimeDate = creationTimeDate
               lastCreatedID = theProj.project.id
             }

--- a/src/common/mixins/scenario.js
+++ b/src/common/mixins/scenario.js
@@ -302,7 +302,7 @@ var ScenarioMixin = {
     applyParamOverwriteSorting3(paramoverwrites) {
       return paramoverwrites.slice(0).sort((po1, po2) =>
         {
-          return (po1.popname.toLowerCase() > po2.popname.toLowerCase())
+          return (this.paramGroups.popnames.lastIndexOf(po1.popname) > this.paramGroups.popnames.lastIndexOf(po2.popname))
         }
       )
     }, 


### PR DESCRIPTION
This PR contains two fixes:
* The sorting order of rows of the parameter overwrites table is fixed so that population groups are sorted by the order of the population groups in the list, rather than alphabetical order.
* In choosing a default active project in the Projects page, the last created project is correctly chosen now.  (There was a bug in the comparison of the creation dates that's now been fixed.)